### PR TITLE
Compas qcrits

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2046,7 +2046,7 @@ component.
       elseif(qcflag.eq.3)then
 *
 * Use the binary_c prescriptions taken from Claeys+2014 Table 2
-* but w/ Hjellming & Webbing for GB/AGB
+* but w/ Hjellming & Webbink for GB/AGB
 * If q1 = m_donor/m_acc > qc then common envelope
 *
          if(kstar(j2).lt.10)then
@@ -2130,6 +2130,39 @@ component.
             qc = 3.5
          elseif(kstar(j1).eq.9)then
             qc = 3.5
+         elseif(kstar(j1).ge.10)then
+            qc = 0.628
+         endif
+      elseif(qcflag.eq.5)then
+*
+* Use the COMPAS prescriptions taken from Neijssel+2020,
+* section 2.3
+* We convert from radial response to qcrit for MS and HG,
+* which assumes conservative mass transfer
+* Stable MT is always assumed for stripped stars
+* Assume standard qcrit from BSE for kstar>=10
+* If q1 = m_donor/m_acc > qc then common envelope
+*
+         if(kstar(j1).eq.0)then
+            qc = 1.717d0
+         elseif(kstar(j1).eq.1)then
+            qc = 1.717d0
+         elseif(kstar(j1).eq.2)then
+            qc = 3.825d0
+         elseif(kstar(j1).eq.3)then
+           qc = 0.362 + 1.0/(3.0*(1.0 - massc(j1)/mass(j1)))
+         elseif(kstar(j1).eq.4)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.5)then
+           qc = 0.362 + 1.0/(3.0*(1.0 - massc(j1)/mass(j1)))
+         elseif(kstar(j1).eq.6)then
+           qc = 0.362 + 1.0/(3.0*(1.0 - massc(j1)/mass(j1)))
+         elseif(kstar(j1).eq.7)then
+            qc = 1000.d0
+         elseif(kstar(j1).eq.8)then
+            qc = 1000.d0
+         elseif(kstar(j1).eq.9)then
+            qc = 1000.d0
          elseif(kstar(j1).ge.10)then
             qc = 0.628
          endif

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -797,8 +797,8 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
             raise ValueError("'{0:s}' needs to be set to either 0, 1, or 2 (you set it to '{1:d}')".format(flag,BSEDict[flag]))
     flag='qcflag'
     if flag in BSEDict.keys():
-        if BSEDict[flag] not in [0,1,2,3,4]:
-            raise ValueError("'{0:s}' needs to be set to 0, 1, 2, 3 or 4(you set it to '{1:0.2f}')".format(flag, BSEDict[flag]))
+        if BSEDict[flag] not in [0,1,2,3,4,5]:
+            raise ValueError("'{0:s}' needs to be set to 0, 1, 2, 3, 4, or 5 (you set it to '{1:0.2f}')".format(flag, BSEDict[flag]))
 
     flag='qcrit_array'
     if flag in BSEDict.keys():

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -489,6 +489,9 @@ common envelope occurs regardless of the choices below:
                             for GB/AGB stars
 
                             ``4`` : follows `Section 5.1 of Belcyznski+2008 <https://ui.adsabs.harvard.edu/abs/2008ApJS..174..223B/abstract>`_ except for WD donors which follow BSE
+
+                            ``5`` : follows `Section 2.3 of Neijssel+2020 <https://ui.adsabs.harvard.edu/abs/2019MNRAS.490.3740N/abstract>`_
+                        Mass transfer from stripped stars is always assumed to be dynamically stable
                          **qcflag = 1**
 
 ``qcrit_array``          Array with length: 16 for user-input values for the 
@@ -550,6 +553,8 @@ common envelope occurs regardless of the choices below:
     ; 1: BSE but with Hjellming & Webbink, 1987, ApJ, 318, 794 GB/AGB stars
     ; 2: following binary_c from Claeys+2014 Table 2
     ; 3: following binary_c from Claeys+2014 Table 2 but with Hjellming & Webbink, 1987, ApJ, 318, 794 GB/AGB stars
+    ; 4: following StarTrack from Belczynski+2008 Section 5.1. WD donors follow standard BSE
+    ; 5: following COMPAS from Neijssel+2020 Section 2.3. Stripped stars are always dynamically stable
     ; default=3
     qcflag=3
 

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -218,6 +218,7 @@ cehestarflag = 0
 ; 2: following binary_c from Claeys+2014 Table 2
 ; 3: following binary_c from Claeys+2014 Table 2 but with Hjellming & Webbink, 1987, ApJ, 318, 794 GB/AGB stars
 ; 4: following StarTrack from Belczynski+2008 Section 5.1. WD donors follow standard BSE
+; 5: following COMPAS from Neijssel+2020 Section 2.3. Stripped stars are always dynamically stable
 ; default = 1
 qcflag = 3
 


### PR DESCRIPTION
added 5th qcflag to match COMPAS, so now we have BSE, StarTrack, binary_c, and COMPAS. 

These are directly out of Neijssel+2020 (https://ui.adsabs.harvard.edu/abs/2019MNRAS.490.3740N/abstract)

The MS and HG qcrits are calculated by converting from the fixed zetas to qcrits, which is what Simone did. These are fairly straightforward to calculate, especially with Mathematica. Just set the below values to dlog(R_RLO)/dlog(m), where R_RLO is the appoximation from Eggleton 1983
MS:  dlog(R∗)/dlog(m) = 2.0
HG:  dlog(R∗)/dlog(m) = 6.5


Here's also a table we can use for docs or talking with vicky or whatever

[qcrit_table.pdf](https://github.com/COSMIC-PopSynth/COSMIC/files/4637315/qcrit_table.pdf)


