### PR TITLE
Fix to ECSN kicks with newly-added kick prescriptons

### DIFF
--- a/cosmic/src/comenv.f
+++ b/cosmic/src/comenv.f
@@ -2,7 +2,7 @@
       SUBROUTINE COMENV(M01,M1,MC1,AJ1,JSPIN1,KW1,
      &                  M02,M2,MC2,AJ2,JSPIN2,KW2,
      &                  ZPARS,ECC,SEP,JORB,COEL,star1,star2,vk,
-     &                  kick_info,formation1,formation2,
+     &                  kick_info,formation1,formation2,sigmahold,
      &                  bhspin1,bhspin2,binstate,mergertype,
      &                  jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &                  lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp)
@@ -80,7 +80,6 @@
 *
       TWOPI = 2.D0*ACOS(-1.D0)
       COEL = .FALSE.
-      sigmahold = sigma
       snp = 0
       output = .false.
 *
@@ -222,10 +221,9 @@
                   if(KW1i.le.6)then
                      if(M1i.le.zpars(5))then
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation1 = 2
                      endif
@@ -233,28 +231,25 @@
                      if(M1i.gt.ecsn_mlow.and.M1i.le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation1 = 2
                      endif
                   elseif(formation1.eq.11)then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 5
                   elseif(KW1i.ge.10.or.KW1i.eq.12)then
 * AIC formation, will never happen here but...
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 4
                   endif
@@ -323,8 +318,8 @@
                    endif
                endif
                CALL kick(KW1,M_postCE,M1,M2,ECC,SEP_postCE,
-     &                   JORB,vk,star1,R2,fallback,kick_info,
-     &                   disrupt)
+     &                   JORB,vk,star1,R2,fallback,sigmahold,
+     &                   kick_info,disrupt)
 * Returning variable state to original naming convention
                MF = M_postCE
                SEPF = SEP_postCE
@@ -520,10 +515,9 @@
                   if(KW1i.le.6)then
                      if(M1i.le.zpars(5))then
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation1 = 2
                      endif
@@ -531,28 +525,25 @@
                      if(M1i.gt.ecsn_mlow.and.M1i.le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation1 = 2
                      endif
                   elseif(formation1.eq.11)then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 5
                   elseif(KW1i.ge.10.or.KW1i.eq.12)then
 * AIC formation, will never happen here but...
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 4
                   endif
@@ -623,17 +614,16 @@
                if(KW1.eq.13.and.KW2.ge.13.and.ussn.eq.1)then
                   if(KW1i.ge.7.and.KW1i.le.9)then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                   formation1 = 3
                   endif
                endif
                CALL kick(KW1,M_postCE,M1,M2,ECC,SEP_postCE,
-     &                   JORB,vk,star1,R2,fallback,kick_info,
-     &                   disrupt)
+     &                   JORB,vk,star1,R2,fallback,sigmahold,
+     &                   kick_info,disrupt)
 * Returning variable state to original naming convention
                MF = M_postCE
                SEPF = SEP_postCE
@@ -680,10 +670,9 @@
                   if(KW2i.le.6)then
                      if(M2i.le.zpars(5))then
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation2 = 2
                      endif
@@ -691,28 +680,25 @@
                      if(M2i.gt.ecsn_mlow.and.M2i.le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                         if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                           sigma = sigmahold/sigmadiv
-                           sigma = -sigma
-                        else
-                           sigma = -1.d0*sigmadiv
+                           sigma = -sigmahold/sigmadiv
+                        elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                           sigma = sigmadiv
                         endif
                         formation2 = 2
                      endif
                   elseif(formation2.eq.11)then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation2 = 5
                   elseif(KW2i.ge.10.or.KW2i.eq.12)then
 * AIC formation, will never happen here but...
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation2 = 4
                   endif
@@ -782,8 +768,8 @@
                    endif
                endif
                CALL kick(KW2,M_postCE,M2,M1,ECC,SEP_postCE,
-     &                   JORB,vk,star2,R1,fallback,kick_info,
-     &                   disrupt)
+     &                   JORB,vk,star2,R1,fallback,sigmahold,
+     &                   kick_info,disrupt)
 * Returning variable state to original naming convention
                MF = M_postCE
                SEPF = SEP_postCE
@@ -912,10 +898,9 @@
                if(KW1i.le.6)then
                   if(M1i.le.zpars(5))then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 2
                   endif
@@ -923,28 +908,25 @@
                   if(M1i.gt.ecsn_mlow.and.M1i.le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation1 = 2
                   endif
                elseif(formation1.eq.11)then
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation1 = 5
                elseif(KW1i.ge.10.or.KW1i.eq.12)then
 * AIC formation, will never happen here but...
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation1 = 4
                endif
@@ -1006,7 +988,7 @@
                    endif
             endif
             CALL kick(KW,MF,M1,0.d0,0.d0,-1.d0,0.d0,vk,star1,
-     &                0.d0,fallback,kick_info,disrupt)
+     &                0.d0,fallback,sigmahold,kick_info,disrupt)
             if(output) write(*,*)'coel 2 6:',KW,M1,M01,R1,MENV,RENV
          ENDIF
          JSPIN1 = OORB*(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1198,10 +1198,9 @@ component.
                if(kstar(k).le.6)then
                   if(mass0(k).le.zpars(5))then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation(k) = 2
                   endif
@@ -1209,29 +1208,26 @@ component.
                   if(mass(k).gt.ecsn_mlow.and.mass(k).le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation(k) = 2
                   endif
                elseif(formation(k).eq.11)then
 * MIC
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 5
                elseif(kstar(k).ge.10.or.kstar(k).eq.12)then
 * AIC formation, will never happen here but...
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 4
                elseif(merger.ge.20.d0)then
@@ -1257,19 +1253,17 @@ component.
                if(formation(k).eq.11)then
 * MIC
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 5
                elseif(kstar(k).ge.10.or.kstar(k).eq.12)then
 * AIC formation, will never happen here but...
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 4
                endif
@@ -1314,7 +1308,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2))
                CALL kick(kw,mass(k),mt,0.d0,0.d0,-1.d0,0.d0,vk,k,
-     &                   0.d0,fallback,kick_info,disrupt)
+     &                   0.d0,fallback,sigmahold,kick_info,disrupt)
 
                sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
 * set kick values for the bcm array
@@ -1353,7 +1347,7 @@ component.
      &                       epoch(2),bhspin(1),bhspin(2))
 
                CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
-     &                   rad(3-k),fallback,kick_info,disrupt)
+     &                   rad(3-k),fallback,sigmahold,kick_info,disrupt)
                sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
 * set kick values for the bcm array
                if(mass(3-k).lt.0.d0)then
@@ -2283,7 +2277,7 @@ component.
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
      &               jspin(j2),kstar(j2),zpars,ecc,sep,jorb,coel,j1,j2,
-     &               vk,kick_info,formation(j1),formation(j2),
+     &               vk,kick_info,formation(j1),formation(j2),sigmahold,
      &               bhspin(j1),bhspin(j2),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &               lumin,B_0,bacc,tacc,epoch,menv,renv)
@@ -3243,10 +3237,9 @@ component.
                if(kstar(k).le.6)then
                   if(mass0(k).le.zpars(5))then
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation(k) = 2
                   endif
@@ -3254,28 +3247,25 @@ component.
                   if(mass(k).gt.ecsn_mlow.and.mass(k).le.ecsn)then
 * BSE orgi: 1.6-2.25, Pod: 1.4-2.5, StarTrack: 1.83-2.25 (all in Msun)
                      if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                        sigma = sigmahold/sigmadiv
-                        sigma = -sigma
-                     else
-                        sigma = -1.d0*sigmadiv
+                        sigma = -sigmahold/sigmadiv
+                     elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                        sigma = sigmadiv
                      endif
                      formation(k) = 2
                   endif
                elseif(formation(k).eq.11)then
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 5
                elseif(kstar(k).ge.10.or.kstar(k).eq.12)then
 * AIC formation, will never happen here but...
                   if(sigma.gt.0.d0.and.sigmadiv.gt.0.d0)then
-                     sigma = sigmahold/sigmadiv
-                     sigma = -sigma
-                  else
-                     sigma = -1.d0*sigmadiv
+                     sigma = -sigmahold/sigmadiv
+                  elseif(sigma.gt.0.d0.and.sigmadiv.lt.0.d0)then
+                     sigma = sigmadiv
                   endif
                   formation(k) = 4
                endif
@@ -3312,7 +3302,7 @@ component.
      &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                    epoch(2),bhspin(1),bhspin(2))
             CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
-     &                rad(3-k),fallback,kick_info,disrupt)
+     &                rad(3-k),fallback,sigmahold,kick_info,disrupt)
             sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
 
             if(mass(3-k).lt.0.d0)then
@@ -3630,7 +3620,7 @@ component.
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
      &               jspin(j2),kstar(j2),zpars,ecc,sep,jorb,coel,j1,j2,
-     &               vk,kick_info,formation(j1),formation(j2),
+     &               vk,kick_info,formation(j1),formation(j2),sigmahold,
      &               bhspin(j1),bhspin(j2),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &               lumin,B_0,bacc,tacc,epoch,menv,renv)
@@ -3711,7 +3701,7 @@ component.
          CALL comenv(mass0(j2),mass(j2),massc(j2),aj(j2),jspin(j2),
      &               kstar(j2),mass0(j1),mass(j1),massc(j1),aj(j1),
      &               jspin(j1),kstar(j1),zpars,ecc,sep,jorb,coel,j1,j2,
-     &               vk,kick_info,formation(j1),formation(j2),
+     &               vk,kick_info,formation(j1),formation(j2),sigmahold,
      &               bhspin(j2),bhspin(j1),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &               lumin,B_0,bacc,tacc,epoch,menv,renv)

--- a/cosmic/src/kick.f
+++ b/cosmic/src/kick.f
@@ -1,6 +1,6 @@
 ***
       SUBROUTINE kick(kw,m1,m1n,m2,ecc,sep,jorb,vk,snstar,
-     &                r2,fallback,kick_info,disrupt)
+     &                r2,fallback,sigmahold,kick_info,disrupt)
       IMPLICIT NONE
       INCLUDE 'const_bse.h'
 *
@@ -67,8 +67,8 @@
       real*8 signs,sigc,psins,psic,cpsins,spsins,cpsic,spsic
       real*8 csigns
       real*8 semilatrec,cangleofdeath,angleofdeath,energy
-      real*8 fallback,bound
-      real*8 mean_mns,mean_mej,alphakick, betakick
+      real*8 fallback,sigmahold,bound
+      real*8 mean_mns,mean_mej,alphakick,betakick
 * Output
       logical output,disrupt
 *
@@ -128,8 +128,12 @@
 * sigma is negative for ECSN
       if((sigma.lt.0.d0).and.(kickflag.eq.0))then
          sigma = -1.d0*sigma
+* for kick prescriptions other than default, revert to original sigma
+      elseif((sigma.lt.0.d0).and.(kickflag.lt.0))then
+         sigma = sigmahold
       endif
       sigmah = sigma
+
 * scale down BH kicks if bhsigmafrac is specified
       if(kickflag.eq.0)then
          if(kw.eq.14.or.(kw.eq.13.and.(m1n.ge.mxns)))then

--- a/cosmic/src/kick.f
+++ b/cosmic/src/kick.f
@@ -230,8 +230,8 @@
 * Use kick scaling from Giacobbo & Mapelli 2020, Eq. 2
              vk = vk * ((m1-m1n)/mean_mej)
           elseif(kickflag.eq.-3)then
-* Use kick scaling from Eldridge & Stanway 2016, Eq. 1
-             vk = alphakick * (m1/m1n) + betakick
+* Use kick scaling from Bray & Eldridge 2016, Eq. 1
+             vk = alphakick * ((m1-m1n)/m1n) + betakick
           endif
              
       endif


### PR DESCRIPTION
Fixed small bug with sigmadiv so that ECSN can be tracked even when sigmadiv is negative (i.e., the user gives a set value for the ECSN sigma). We were doing this incorrectly before. 

Also now pass sigmahold to comenv and kick, so that we know what the original input for the sigma parameter is and we can revert to it when using certain kick distributions. 