### PR TITLE
Changing qc check to encompass all MS stars re: #452

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2169,7 +2169,7 @@ component.
          qc = qc_fixed
       endif
 
-      if(kstar(j1).eq.0.and.q(j1).gt.qc)then
+      if((kstar(j1).le.1.or.kstar(j1).eq.7).and.q(j1).gt.qc)then
 *
 * This will be dynamical mass transfer of a similar nature to
 * common-envelope evolution.  The result is always a single


### PR DESCRIPTION
fixing qcrit checks to treat all MS (kstar=0,1,7) w/ qc>qcrit the sam…e way. we talked about this in the cosmic call
This fixes issue #452