### PR TITLE
Re-allowing timestep_conditions

### DIFF
--- a/cosmic/checkstate.py
+++ b/cosmic/checkstate.py
@@ -71,7 +71,7 @@ def set_checkstates(timestep_conditions=[]):
             would skip to only printing the final state
     """
     # assume that we are not doing any special dtp setting
-    _evolvebin.checkstate_array.check_dtp = 0
+    _evolvebin.check_dtp.check_dtp = 0
 
     # Set the default state for checkstate which is that there are no
     # conditional states at which to set a special dtp
@@ -84,7 +84,7 @@ def set_checkstates(timestep_conditions=[]):
 
     for index, condition in enumerate(timestep_conditions):
         # we are checking for conditions
-        _evolvebin.checkstate_array.check_dtp = 1
+        _evolvebin.check_dtp.check_dtp = 1
         conditions = parse_column_filters(condition)
         for param in conditions:
             # find where in the checkstate_array this param is


### PR DESCRIPTION
changing the common block declaration for the timestep_conditions to point to the right place -- it was looking in checkstate_array instead of check_dtp to set the check_dtp variable which allows the timestep_conditions to happen

This solves issue #461.