### PR TITLE
sub-Eddington accretion in the docs and example Params.ini

### DIFF
--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -1001,6 +1001,8 @@ common envelope occurs regardless of the choices below:
 
                             ``values >1`` : permit super-Eddington accretion
                             up to value of *eddfac*
+                            ``values 0<=eddfac<1`` : restrict accretion limit
+                            to fraction of Eddington (sub-Eddington accretion)
 
                          **eddfac = 1.0**
 

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -366,7 +366,8 @@ bhspinmag = 0.0
 ;;; MASS TRANSFER FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; eddfac is Eddington limit factor for mass transfer
+; eddfac is Eddington limit factor for mass transfer, which can be 1 for Eddington-limited, >1 for super-Eddington, and 
+; <1 for sub-Eddington
 ; default = 1.0
 eddfac = 1.0
 


### PR DESCRIPTION
changed docs to reflect that eddfac flag can be less than 1, which allows for sub-Eddington accretion. The flag checks in utils.py already allow for any eddfac >= 0. 

Let me know if I missed any docs!