### PR TITLE
Fix to bug with acc_lim flag not imposing Eddington limit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,6 +48,5 @@ jobs:
       run: |
         bash ci/compile_benchmark.sh
         pytest --cov=./cosmic --cov-report=xml
-        cd docs && make html; cd ../
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2747,19 +2747,9 @@ component.
                endif
 *
             endif
-         elseif(kstar(j2).ge.10)then
-*
-* Impose the Eddington limit.
-*
-            dm2 = MIN(dm1,dme)
-            if(dm2.lt.dm1) supedd = .true.
-* Can add pulsar propeller evolution here if need be. PK.
-*
-*
-         else
+         elseif(kstar(j2).eq.3.or.kstar(j2).eq.5.or.kstar(j2).eq.6)then
 * We have a giant w/ kstar(j2) = 3,5,6
 *
-
             if(acc_lim.eq.0.or.acc_lim.eq.-1)then
                dm2 = dm1
             elseif(acc_lim.eq.-2)then
@@ -2768,7 +2758,6 @@ component.
                dm2 = MIN(1.d0,taum/tkh(j2))*dm1
             endif
 
-
          endif
 
 *
@@ -2776,6 +2765,17 @@ component.
 *
          if(acc_lim.gt.0)then
             dm2 = acc_lim*dm1
+         endif
+
+*
+* Impose the Eddington limit.
+*
+         if(kstar(j2).ge.10)then
+            dm2 = MIN(dm1,dme)
+            if(dm2.lt.dm1) supedd = .true.
+*
+* Can add pulsar propeller evolution here if need be. PK.
+*
          endif
 
 

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2680,7 +2680,7 @@ component.
                dm2 = MIN(1.d0,10.d0*taum/tkh(j2))*dm1
             elseif(acc_lim.eq.-1.d0.or.acc_lim.eq.-3)then
                dm2 = MIN(1.d0,taum/tkh(j2))*dm1
-            elseif(acc_lim.gt.0.d0)then
+            elseif(acc_lim.ge.0.d0)then
                dm2 = acc_lim*dm1
             endif
          elseif(kstar(j2).ge.7.and.kstar(j2).le.9)then
@@ -2693,7 +2693,7 @@ component.
                   dm2 = MIN(1.d0,10.d0*taum/tkh(j2))*dm1
                elseif(acc_lim.eq.-1.d0.or.acc_lim.eq.-3)then
                   dm2 = MIN(1.d0,taum/tkh(j2))*dm1
-               elseif(acc_lim.gt.0.d0)then
+               elseif(acc_lim.ge.0.d0)then
                   dm2 = acc_lim*dm1
                endif
             else
@@ -2712,7 +2712,7 @@ component.
                      CALL gntage(mcx,mt2,kst,zpars,mass0(j2),aj(j2))
                      epoch(j2) = tphys + dtm - aj(j2)
                   endif
-               elseif(acc_lim.gt.0.d0)then
+               elseif(acc_lim.ge.0.d0)then
                   dm2 = acc_lim*dm1
                endif
             endif
@@ -2727,18 +2727,21 @@ component.
 * Accrete until a nova explosion blows away most of the accreted material.
 *
                   novae = .true.
-                  dm2 = MIN(dm1,dme)
-                  if(dm2.lt.dm1) supedd = .true.
-                  dm22 = epsnov*dm2
-                  if(acc_lim.gt.0.d0)then
+                  if(acc_lim.lt.0.d0)then
+                     dm2 = MIN(dm1,dme)
+                     if(dm2.lt.dm1) supedd = .true.
+                  elseif(acc_lim.ge.0.d0)then
                      dm2 = MIN(dm2,acc_lim*dm1)
-                  endif
+                     if(dm2.lt.acc_lim*dm1) supedd = .true.
+                  endif   
+                  dm22 = epsnov*dm2
                else
 *
 * Steady burning at the surface
 *
-                  dm2 = dm1
-                  if(acc_lim.gt.0.d0)then
+                  if(acc_lim.lt.0.d0)then
+                     dm2 = dm1
+                  elseif(acc_lim.ge.0.d0)then
                      dm2 = acc_lim*dm1
                   endif
                endif
@@ -2746,8 +2749,9 @@ component.
 *
 * Make a new giant envelope.
 *
-               dm2 = dm1
-               if(acc_lim.gt.0.d0)then
+               if(acc_lim.lt.0.d0)then
+                  dm2 = dm1
+               elseif(acc_lim.ge.0.d0)then
                   dm2 = MIN(dm2,acc_lim*dm1)
                endif
 *
@@ -2774,7 +2778,7 @@ component.
                dm2 = MIN(1.d0,10*taum/tkh(j2))*dm1
             elseif(acc_lim.eq.-3)then
                dm2 = MIN(1.d0,taum/tkh(j2))*dm1
-            elseif(acc_lim.gt.0.d0)then
+            elseif(acc_lim.ge.0.d0)then
                dm2 = MIN(dm2,acc_lim*dm1)
             endif
 
@@ -2784,11 +2788,13 @@ component.
 * Impose the Eddington limit.
 *
          if(kstar(j2).ge.10)then
-            dm2 = MIN(dm1,dme)
+            if(acc_lim.lt.0.d0)then
+               dm2 = MIN(dm1,dme)
+               if(dm2.lt.dm1) supedd = .true.
             if(acc_lim.gt.0.d0)then
-                dm2 = MIN(acc_lim*dm1,dme)
+               dm2 = MIN(acc_lim*dm1,dme)
+               if(dm2.lt.acc_lim*dm1) supedd = .true.
             endif
-            if(dm2.lt.dm1) supedd = .true.
 *
 * Can add pulsar propeller evolution here if need be. PK.
 *

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2699,21 +2699,21 @@ component.
             else
                if(acc_lim.lt.0.d0)then
                   dm2 = dm1
-                  dmchk = dm2 - 1.05d0*dms(j2)
-                  if(dmchk.gt.0.d0.and.dm2/mass(j2).gt.1.0d-04)then
-                     kst = MIN(6,2*kstar(j2)-10)
-                     if(kst.eq.4)then
-                        aj(j2) = aj(j2)/tms(j2)
-                        mcx = mass(j2)
-                     else
-                        mcx = massc(j2)
-                     endif
-                     mt2 = mass(j2) + km*(dm2 - dms(j2))
-                     CALL gntage(mcx,mt2,kst,zpars,mass0(j2),aj(j2))
-                     epoch(j2) = tphys + dtm - aj(j2)
-                  endif
                elseif(acc_lim.ge.0.d0)then
                   dm2 = acc_lim*dm1
+               endif
+               dmchk = dm2 - 1.05d0*dms(j2)
+               if(dmchk.gt.0.d0.and.dm2/mass(j2).gt.1.0d-04)then
+                  kst = MIN(6,2*kstar(j2)-10)
+                  if(kst.eq.4)then
+                     aj(j2) = aj(j2)/tms(j2)
+                     mcx = mass(j2)
+                  else
+                     mcx = massc(j2)
+                  endif
+                  mt2 = mass(j2) + km*(dm2 - dms(j2))
+                  CALL gntage(mcx,mt2,kst,zpars,mass0(j2),aj(j2))
+                  epoch(j2) = tphys + dtm - aj(j2)
                endif
             endif
          elseif(kstar(j1).le.6.and.
@@ -2791,7 +2791,7 @@ component.
             if(acc_lim.lt.0.d0)then
                dm2 = MIN(dm1,dme)
                if(dm2.lt.dm1) supedd = .true.
-            if(acc_lim.gt.0.d0)then
+            elseif(acc_lim.gt.0.d0)then
                dm2 = MIN(acc_lim*dm1,dme)
                if(dm2.lt.acc_lim*dm1) supedd = .true.
             endif


### PR DESCRIPTION
hopefully fixed the bug that doesn't account for eddington when acc_lim>0 is set. I just moved this outside the large if statement, was concerned that this wouldn't work because of the white dwarf accretor with kstar leq 6 part of the if statement, but after reading through it a few times I'm pretty sure it should be fine (since the eddington limit is already imposed in that part)