### PR TITLE
rethinking convergence and filtering

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -347,8 +347,6 @@ if __name__ == '__main__':
         # Keep track of the index
         idx = int(bcm.bin_num.max()+1)
 
-        import pdb
-        pdb.set_trace()
         # If dtp is not set, filter out first timestep in bcm
         if np.all(dtp == IBT['tphysf'].values):
             bcm = bcm.loc[bcm['tphys'].isin(dtp)]
@@ -362,7 +360,6 @@ if __name__ == '__main__':
         if conv_filter.empty:
             warnings.warn("After filtering for desired convegence systems there were no systems matching your request. It is possible you are suggesting incompatible bin_state choices and convergence_filters, e.g. bin_state=[0,1], convergence_filter='disruption'")
             log_file.write("After filtering for desired convegence systems there were no systems matching your request. It is possible you are suggesting incompatible bin_state choices and convergence_filters, e.g. bin_state=[0,1], convergence_filter='disruption'")
-            continue
 
         bcm_filter = bcm.loc[bcm.bin_num.isin(conv_filter.bin_num)]
         bpp_filter = bpp.loc[bpp.bin_num.isin(conv_filter.bin_num)]
@@ -374,11 +371,10 @@ if __name__ == '__main__':
         if bcm_filter.empty:
             warnings.warn("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep")
             log_file.write("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep\n")
-            continue
         initC_filter = initC_filter.loc[initC_filter.bin_num.isin(bcm_filter.bin_num)]
         kick_info_filter = kick_info_filter.loc[kick_info_filter.bin_num.isin(bcm_filter.bin_num)]
         bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(bcm_filter.bin_num)]
-
+        conv_filter = conv_filter.loc[conv_filter.bin_num.isin(bcm_filter.bin_num)]
 
         if convergence['bcm_bpp_initCond_filter'] == True:
             initC_filter = initC_filter.loc[initC_filter.bin_num.isin(conv_lims_bin_num)]

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -347,35 +347,45 @@ if __name__ == '__main__':
         # Keep track of the index
         idx = int(bcm.bin_num.max()+1)
 
+        import pdb
+        pdb.set_trace()
         # If dtp is not set, filter out first timestep in bcm
         if np.all(dtp == IBT['tphysf'].values):
             bcm = bcm.loc[bcm['tphys'].isin(dtp)]
 
-        bcm_filter, bin_state_nums = utils.filter_bpp_bcm(bcm, bpp, filters, kstar1_range, kstar2_range)
-        if bcm_filter.empty:
-            warnings.warn("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep")
-            log_file.write("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep\n")
-            continue
-
-        initC_filter = initCond.loc[initCond.bin_num.isin(bcm_filter.bin_num)]
-        kick_info_filter = kick_info.loc[kick_info.bin_num.isin(bcm_filter.bin_num)]
-        bpp_filter = bpp.loc[bpp.bin_num.isin(bcm_filter.bin_num)]
-        # Now get the converging population
-        conv_filter = utils.conv_select(bcm_filter, bpp_filter,
-                                        kstar1_range, kstar2_range,
-                                        convergence['convergence_filter'],
-                                        convergence['convergence_limits'])
+        # Now get the converging population and bin_nums for conv systems whic
+        # satisfy the convergence_limits
+        conv_filter, conv_lims_bin_num = utils.conv_select(bcm, bpp,
+                                                           kstar1_range, kstar2_range,
+                                                           convergence['convergence_filter'],
+                                                           convergence['convergence_limits'])
         if conv_filter.empty:
             warnings.warn("After filtering for desired convegence systems there were no systems matching your request. It is possible you are suggesting incompatible bin_state choices and convergence_filters, e.g. bin_state=[0,1], convergence_filter='disruption'")
             log_file.write("After filtering for desired convegence systems there were no systems matching your request. It is possible you are suggesting incompatible bin_state choices and convergence_filters, e.g. bin_state=[0,1], convergence_filter='disruption'")
             continue
 
-        if convergence['bcm_bpp_initCond_filter']:
-            bcm_filter = bcm_filter.loc[bcm_filter.bin_num.isin(conv_filter.bin_num)]
-            bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(conv_filter.bin_num)]
-            initC_filter = initC_filter.loc[initC_filter.bin_num.isin(conv_filter.bin_num)]
-            kick_info_filter = kick_info_filter.loc[kick_info_filter.bin_num.isin(conv_filter.bin_num)]
+        bcm_filter = bcm.loc[bcm.bin_num.isin(conv_filter.bin_num)]
+        bpp_filter = bpp.loc[bpp.bin_num.isin(conv_filter.bin_num)]
+        initC_filter = initCond.loc[initCond.bin_num.isin(conv_filter.bin_num)]
+        kick_info_filter = kick_info.loc[kick_info.bin_num.isin(conv_filter.bin_num)]
 
+        # Filter the bin_state based on user specified filters
+        bcm_filter, bin_state_nums = utils.filter_bin_state(bcm_filter, bpp_filter, filters, kstar1_range, kstar2_range)
+        if bcm_filter.empty:
+            warnings.warn("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep")
+            log_file.write("After filtering the bcm array for desired systems there were no systems matching your request. It is possible you should up to the number of binaries provessed in each iteration, i.e. Nstep\n")
+            continue
+        initC_filter = initC_filter.loc[initC_filter.bin_num.isin(bcm_filter.bin_num)]
+        kick_info_filter = kick_info_filter.loc[kick_info_filter.bin_num.isin(bcm_filter.bin_num)]
+        bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(bcm_filter.bin_num)]
+
+
+        if convergence['bcm_bpp_initCond_filter'] == True:
+            initC_filter = initC_filter.loc[initC_filter.bin_num.isin(conv_lims_bin_num)]
+            kick_info_filter = kick_info_filter.loc[kick_info_filter.bin_num.isin(conv_lims_bin_num)]
+            bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(conv_lims_bin_num)]
+        
+        conv_filter = conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)]
 
         # Filter the bcm and bpp arrays according to user specified filters
         if len(bcm_filter_match) == 0:
@@ -389,7 +399,7 @@ if __name__ == '__main__':
             bpp_filter_match = bpp_filter_match.append(bpp_filter)
             initC_filter_match = initC_filter_match.append(initC_filter)
             kick_info_filter_match = kick_info_filter_match.append(kick_info_filter)
-            conv_filter_match = conv_filter_match.append(conv_filter)
+            conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
 
         if len(conv_filter_match) >= np.min([50, args.Niter]):
             conv_save = conv_save.append(conv_filter_match)

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -108,12 +108,15 @@ def parse_commandline():
     parser.add_argument("--SF_start", help="Sets the time in the past when star formation initiates in Myr", type=float)
     parser.add_argument("--SF_duration", help="Sets the duration of constant star formation in Myr", type=float)
     parser.add_argument("--metallicity", type=float)
-    parser.add_argument("--convergence_params", nargs='+',)
-    parser.add_argument("--convergence_limits", type=json.loads)
-    parser.add_argument("--convergence_filter")
-    parser.add_argument("--match", type=float)
-    parser.add_argument("--bcm_bpp_initcond_filter", type=str2bool, nargs='?',
-                        const=True, default=False,)
+    parser.add_argument("--convergence_params", nargs='+', help="specifies the list of parameters for which you"
+                                                                " would like to track the distribution shapes for convergence")
+    parser.add_argument("--convergence_limits", type=json.loads, help="dictionary that can contain limits for convergence params")
+    parser.add_argument("--pop_select", help="Used in combination with the specified final_kstar1 and final_kstar2 values"
+                                             " to select the subpopulation of interest from the evolved population")
+    parser.add_argument("--match", type=float, help="provides the tolerance for the convergence calculation")
+    parser.add_argument("--apply_convergence_limits", type=str2bool, nargs='?',
+                        const=True, default=False, help="filters the evolved binary population to contain"
+                                                        " only the binaries that satsify the convergence limits")
     parser.add_argument("--seed", type=int)
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")
@@ -355,7 +358,7 @@ if __name__ == '__main__':
         # satisfy the convergence_limits
         conv_filter, conv_lims_bin_num = utils.conv_select(bcm, bpp,
                                                            kstar1_range, kstar2_range,
-                                                           convergence['convergence_filter'],
+                                                           convergence['pop_select'],
                                                            convergence['convergence_limits'])
         if conv_filter.empty:
             warnings.warn("After filtering for desired convegence systems there were no systems matching your request. It is possible you are suggesting incompatible bin_state choices and convergence_filters, e.g. bin_state=[0,1], convergence_filter='disruption'")
@@ -376,7 +379,7 @@ if __name__ == '__main__':
         bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(bcm_filter.bin_num)]
         conv_filter = conv_filter.loc[conv_filter.bin_num.isin(bcm_filter.bin_num)]
 
-        if convergence['bcm_bpp_initCond_filter'] == True:
+        if convergence['apply_convergence_limits'] == True:
             initC_filter = initC_filter.loc[initC_filter.bin_num.isin(conv_lims_bin_num)]
             kick_info_filter = kick_info_filter.loc[kick_info_filter.bin_num.isin(conv_lims_bin_num)]
             bpp_filter = bpp_filter.loc[bpp_filter.bin_num.isin(conv_lims_bin_num)]

--- a/cosmic/tests/test_utils.py
+++ b/cosmic/tests/test_utils.py
@@ -56,44 +56,44 @@ _KNOWN_METHODS = ['select_final_state',
 class TestUtils(unittest.TestCase):
     """`TestCase` for the utilities method
     """
-    def test_filter_bpp_bcm(self):
-        self.assertRaises(ValueError, utils.filter_bpp_bcm, BCM_TEST, BPP_TEST, wrong_dict, kstar_double, kstar_double)
+    def test_filter_bin_state(self):
+        self.assertRaises(ValueError, utils.filter_bin_state, BCM_TEST, BPP_TEST, wrong_dict, kstar_double, kstar_double)
 
-        bcm_true, bin_state_fraction = utils.filter_bpp_bcm(BCM_TEST, BPP_TEST, alive_dict, k1_range, k2_range)
+        bcm_true, bin_state_fraction = utils.filter_bin_state(BCM_TEST, BPP_TEST, alive_dict, k1_range, k2_range)
 
         self.assertTrue(bcm_true.tphys.all() >= 1.0)
 
-        bcm_false, bin_state_fraction = utils.filter_bpp_bcm(BCM_TEST, BPP_TEST, false_dict, k1_range_false, k2_range_false)
+        bcm_false, bin_state_fraction = utils.filter_bin_state(BCM_TEST, BPP_TEST, false_dict, k1_range_false, k2_range_false)
 
 
     def test_conv_select(self):
         self.assertRaises(ValueError, utils.conv_select, BCM_TEST, BPP_TEST, [11], [11], wrong_dict, {})
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['convergence_filter'], {})
         self.assertTrue(np.all(conv.evol_type.isin([2,4])))
         self.assertTrue(np.all(conv.sep >= 0))
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_1_SN['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_1_SN['convergence_filter'], {})
         self.assertEqual(len(conv), 0)
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_2_SN['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_2_SN['convergence_filter'], {})
         self.assertEqual(len(conv), 0)
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_disruption['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_disruption['convergence_filter'], {})
         self.assertEqual(len(conv), 4)
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_final_state['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_final_state['convergence_filter'], {})
         self.assertEqual(len(conv), int(len(BCM_TEST)))
 
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_XRB_form['convergence_filter'], {})
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_XRB_form['convergence_filter'], {})
         self.assertEqual(len(conv), 0)
 
         self.assertRaises(ValueError, utils.conv_select, BCM_TEST, BPP_TEST, [11], [11], false_dict, {})
 
     def test_conv_lims(self):
-        conv = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['convergence_filter'], conv_lim_dict)
-        self.assertTrue(conv.sep.max() < conv_lim_dict["sep"][1])
-        self.assertTrue(conv.sep.min() > conv_lim_dict["sep"][0])
+        conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['convergence_filter'], conv_lim_dict)
+        self.assertTrue(conv.loc[conv.bin_num.isin(bin_nums)].sep.max() < conv_lim_dict["sep"][1])
+        self.assertTrue(conv.loc[conv.bin_num.isin(bin_nums)].sep.min() > conv_lim_dict["sep"][0])
 
     def test_idl_tabulate(self):
         # Give this custom integrator a simple integration

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -39,7 +39,7 @@ __credits__ = [
     "Michael Zevin <zevin@northwestern.edu>",
 ]
 __all__ = [
-    "filter_bpp_bcm",
+    "filter_bin_state",
     "conv_select",
     "mass_min_max_select",
     "idl_tabulate",
@@ -57,8 +57,9 @@ __all__ = [
 ]
 
 
-def filter_bpp_bcm(bcm, bpp, method, kstar1_range, kstar2_range):
-    """Filter the output of bpp and bcm
+def filter_bin_state(bcm, bpp, method, kstar1_range, kstar2_range):
+    """Filter the output of bpp and bcm, where the kstar ranges
+    have already been selected by the conv_select module
 
     Parameters
     ----------
@@ -105,12 +106,8 @@ def filter_bpp_bcm(bcm, bpp, method, kstar1_range, kstar2_range):
             # that are alive today we can simply check the last entry in the bcm
             # array for the system and see what its properities are today
             bcm_0_2 = bcm_last_entry.loc[(bcm_last_entry.bin_state != 1)]
-            bin_num_save.extend(
-                bcm_0_2.loc[
-                    (bcm_0_2.kstar_1.isin(kstar1_range))
-                    & (bcm_0_2.kstar_2.isin(kstar2_range))
-                ].bin_num.tolist()
-            )
+            bin_num_save.extend(bcm_0_2.bin_num.tolist())
+
             # in order to find the properities of merged systems
             # we actually need to search in the BPP array for the properities
             # of the objects right at merge because the bcm will report
@@ -325,9 +322,12 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
         for key in conv_lims.keys():
             filter_lo = conv_lims[key][0]
             filter_hi = conv_lims[key][1]
-            conv_save = conv_save.loc[conv_save[key] < filter_hi]
-            conv_save = conv_save.loc[conv_save[key] > filter_lo]
-    return conv_save
+            conv_save_lim = conv_save.loc[conv_save[key] < filter_hi]
+            conv_lims_bin_num = conv_save_lim.loc[conv_save[key] > filter_lo].bin_num
+    else:
+        conv_lims_bin_num = conv_save.bin_num
+
+    return conv_save, conv_lims_bin_num
 
 
 def pop_write(

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -126,62 +126,64 @@ sampling
 [convergence]
 -------------
 
-===========================  ===================================================================================
-``convergence_params``       A list of parameters you would like to verify have converged
-                             to a single distribution shape.
-                             Options include: ``mass_1``, ``mass_2``, ``sep``, ``porb``,
-                             ``ecc``, ``massc_1``, ``massc_2``, ``rad_1``, ``rad_2``
+============================  ===================================================================================
+``convergence_params``        A list of parameters you would like to verify have converged
+                              to a single distribution shape.
+                              Options include: ``mass_1``, ``mass_2``, ``sep``, ``porb``,
+                              ``ecc``, ``massc_1``, ``massc_2``, ``rad_1``, ``rad_2``
 
-``convergence_limits``       Specifies limits for parameters included in the convergence
-                             params list. If specified, the lower and upper limit must
-                             be specified:
+``convergence_limits``        Specifies limits for parameters included in the convergence
+                              params list. If specified, the lower and upper limit must
+                              be specified:
 
-                                ``convergence_limits = {'mass_1' : [5, 10], 'sep' : [0, 10]}``
+                                 ``convergence_limits = {'mass_1' : [5, 10], 'sep' : [0, 10]}``
 
-``convergence_filter``       Selects the stage of the evolution at which you would like
-                             to check for convergence. This will filter for systems that
-                             satisfy the final_kstar1 and final_kstar2 selections from
-                             the command line call of cosmic-pop
+``pop_select``                Selects the stage of the evolution at which you would like
+                              to check for convergence. This will filter for systems that
+                              satisfy the final_kstar1 and final_kstar2 selections from
+                              the command line call of cosmic-pop
 
-                                ``formation``: computes convergence on binary properties
-                                at formation with user-specified final kstars
+                                 ``formation``: computes convergence on binary properties
+                                 at formation with user-specified final kstars
 
-                                ``1_SN``: computes convergence on binary properties
-                                just before the first supernova for the population with
-                                user-specified final kstars
+                                 ``1_SN``: computes convergence on binary properties
+                                 just before the first supernova for the population with
+                                 user-specified final kstars
 
-                                ``2_SN``: computes convergence on binary properties
-                                just before the second supernova for the population with
-                                user-specified final kstars
+                                 ``2_SN``: computes convergence on binary properties
+                                 just before the second supernova for the population with
+                                 user-specified final kstars
 
-                                ``disruption``: computes convergence on binary properties
-                                just before disruption of the population with
-                                user-specified final kstars
+                                 ``disruption``: computes convergence on binary properties
+                                 just before disruption of the population with
+                                 user-specified final kstars
 
-                                ``final_state``: computes convergence on binary properties
-                                after the full evolution specified by the user-supplied evolution time
-                                and with the user specified final kstars
+                                 ``final_state``: computes convergence on binary properties
+                                 after the full evolution specified by the user-supplied evolution time
+                                 and with the user specified final kstars
 
-                                ``XRB_form``: computes convergence on binary properties
-                                at the start of RLO following the first supernova on the population with
-                                user-specified final kstars
+                                 ``XRB_form``: computes convergence on binary properties
+                                 at the start of RLO following the first supernova on the population with
+                                 user-specified final kstars
 
-``match``                    match provides the tolerance for the convergence calculation
-                             and is calculated as match = Log\ :sub:`10` (1-convergence)
+``match``                     match provides the tolerance for the convergence calculation
+                              and is calculated as match = Log\ :sub:`10` (1-convergence)
 
-``bcm_bpp_initCond_filter``  The bcm_bpp_initCond_filter will filter the bcm, bpp, and initCond
-                             DataFrames to only contain the binaries that satisfy the constraints
-                             from ``convergence_limits`` and/or ``convergence_filer``
+``apply_convergence_limits``  apply_convergence_limits will filter the binary population,
+                              including the bcm, bpp, initCond, and kick_info
+                              DataFrames to only contain the binaries that satisfy the constraints
+                              from ``convergence_limits``
 
-                                ``True``: bcm, bpp, initCond will contain only the binaries which
-                                are in the conv DataFrame
+                                 ``True``: bcm, bpp, initCond, kick_info will contain only the binaries which
+                                 are in the conv DataFrame
 
-                                ``False``: bcm, bpp, initCond will contain all systems which satisfy the
-                                final kstar selection and will **not** be filtered.
+                                 ``False``: bcm, bpp, initCond, infor will contain all systems which satisfy the
+                                 final kstar and pop_select selection and will **not** be filtered based on the
+                                 convergence_limits
 
-                             **bcm_bpp_initCond_filter=False**
+                              **bcm_bpp_initCond_filter=False**
 
-===========================  ===================================================================================
+============================  ===================================================================================
 
 .. code-block:: ini
 

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -58,15 +58,13 @@ metallicity = 0.014
 keep_singles = False
 
 [convergence]
-; A list of parameters you would like to verify have converged
-; to a single distribution shape.
-; Options include mass_1, mass_2, sep, porb, ecc, massc_1, massc_2
-; rad_1, rad_2
-convergence_params = [mass_1,mass_2,porb,ecc]
 
-; convergence_limits is a dictionary that can contain limits for convergence params
-; convergence_limits = {"mass_1" : [0, 20], "sep" : [0,5000]}
-convergence_limits = {}
+; pop_select tells cosmic-pop which sub-population to select
+; from the evolved population. It is used in combination 
+; with the specified final_kstar1 and final_kstar2 values
+; to select the binary stars of interest from the
+; evolved population (which includes the bcm, bpp, initC,
+; and kick_info dataframes)
 
 ; formation computes convergence on binary properties
 ; at formation with user-specified final kstars
@@ -90,16 +88,27 @@ convergence_limits = {}
 ; XRB_form computes convergence on binary properties
 ; at the start of RLO following the first supernova on the population with
 ; user-specified final kstars
-convergence_filter = formation
+pop_select = formation
+
+; convergenc_params specifies the list of parameters for which you 
+; would like to track the distribution shapes
+; Options include mass_1, mass_2, sep, porb, ecc, massc_1, massc_2
+; rad_1, rad_2
+convergence_params = [mass_1,mass_2,porb,ecc]
+
+; convergence_limits is a dictionary that can contain limits for convergence params
+; convergence_limits = {"mass_1" : [0, 20], "sep" : [0,5000]}
+convergence_limits = {}
+
+; apply_convergence_limits filters the evolved binary population 
+; to only the binaries that satsify the convergence limits
+; selection critera if True
+apply_convergence_limits = False
 
 ; match provides the tolerance for the convergence calculation
 ; and is calculated as match = log10(1-convergence)
 ; default = -5.0
 match = -6.0
-
-; bcm_bpp_initCond_filter filters the bcm/bpp/initCond
-; arrays to only the binaries that are in the conv array if true
-bcm_bpp_initCond_filter = False
 
 
 [rand_seed]


### PR DESCRIPTION
Renamed filter_bpp_bcm to filter_bin_state, reordered filtering so that we don't lose intermediate evolutionary states (e.g. xrbs) with the bin_state filtering.

Now the process is: 
(-) get the converging data set and bin_nums for conv_limits
(-) filter the converging data set on bin_state choice
(-) filter bcm/bpp/initC/kick to only contain data within conv_limits if user specified request to filter them, otherwise, don't
(-) compute convergence on conv dataframe with conv_limits
