### PR TITLE
it makes more sense to not include sep > 0 in this filtering

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -296,7 +296,8 @@ if __name__ == '__main__':
                                                         SF_start = sampling['SF_start'],
                                                         SF_duration = sampling['SF_duration'],
                                                         met = sampling['metallicity'],
-                                                        size = args.Nstep)
+                                                        size = args.Nstep,
+                                                        params = args.params)
             IBT, mass_singles, mass_binaries, n_singles, n_binaries = init_samp_list
 
         if sampling['sampling_method'] == 'multidim':

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -226,7 +226,6 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
         conv_save = bpp_save.loc[
             (bpp_save.kstar_1.isin(final_kstar_1))
             & (bpp_save.kstar_2.isin(final_kstar_2))
-            & (bpp_save.sep > 0)
             & (bpp_save.evol_type.isin([2.0, 4.0]))
         ]
 


### PR DESCRIPTION
This solves issue: #518
The previous code was particularly problematic for populations where you are interested in *both* the merging compact objects and the XRB population