### PR TITLE
fixed bug which supplied incorrect path to params file in cosmic-pop

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -297,7 +297,7 @@ if __name__ == '__main__':
                                                         SF_duration = sampling['SF_duration'],
                                                         met = sampling['metallicity'],
                                                         size = args.Nstep,
-                                                        params = args.params)
+                                                        params = args.inifile)
             IBT, mass_singles, mass_binaries, n_singles, n_binaries = init_samp_list
 
         if sampling['sampling_method'] == 'multidim':


### PR DESCRIPTION
This is a great lesson in making sure that your non-automated tests are correct and testing the code you want them to!

Needed to supply `args.inifile` instead of `args.params` to the independent sampler in cosmic-pop