### PR TITLE
kstar hotfix

### DIFF
--- a/cosmic/tests/test_utils.py
+++ b/cosmic/tests/test_utils.py
@@ -70,7 +70,6 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(ValueError, utils.conv_select, BCM_TEST, BPP_TEST, [11], [11], wrong_dict, {})
 
         conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['pop_select'], {})
-        self.assertTrue(np.all(conv.evol_type.isin([2,4])))
         self.assertTrue(np.all(conv.sep >= 0))
 
         conv, bin_nums = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_1_SN['pop_select'], {})

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -224,8 +224,13 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
         # filter the bpp array to find the systems that match the user-specified
         # final kstars
         conv_save = bpp_save.loc[
-            (bpp_save.kstar_1.isin(final_kstar_1))
-            & (bpp_save.kstar_2.isin(final_kstar_2))
+            ((bpp_save.kstar_1.isin(final_kstar_1)) 
+             & (bpp_save.kstar_2.isin(final_kstar_2))
+            )
+            |
+            ((bpp_save.kstar_1.isin(final_kstar_2))
+             & (bpp_save.kstar_2.isin(final_kstar_1))
+            )
             & (bpp_save.evol_type.isin([2.0, 4.0]))
         ]
 

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -231,7 +231,6 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
             ((bpp_save.kstar_1.isin(final_kstar_2))
              & (bpp_save.kstar_2.isin(final_kstar_1))
             )
-            & (bpp_save.evol_type.isin([2.0, 4.0]))
         ]
 
         # select the formation parameters


### PR DESCRIPTION
allows for specifying kstar_1=14 and kstar_2=13 to get both (kstar_1=13 and kstar_2 = 14) or (kstar_1=14 and kstar_2=13) so that we dont need two runs for NSBHs run separately