### PR TITLE
correcting the upper end of the pisn gap in the Marchant+ prescription

### DIFF
--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -758,7 +758,7 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                            mt = polyfit
                            pisn_track(kidx)=6
                         elseif(mcbagb.gt.61.10d0.and.
-     &                         mcbagb.lt.113.29d0)then
+     &                         mcbagb.lt.124.12d0)then
                            mt = 0.d0
                            kw = 15
                            pisn_track(kidx)=7
@@ -1135,7 +1135,7 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                            mt = polyfit
                            pisn_track(kidx)=6
                         elseif(mc.gt.61.10d0.and.
-     &                         mc.lt.113.29d0)then
+     &                         mc.lt.124.12d0)then
                            mt = 0.d0
                            kw = 15
                            pisn_track(kidx)=7


### PR DESCRIPTION
See Table 1 of [Marchant+2019](https://iopscience.iop.org/article/10.3847/1538-4357/ab3426/pdf). We were accidentally using the column with CO core mass rather than the column with He core mass for defining the top of the PISN mass gap in the Marchant prescription. 