### PR TITLE
Sse changes

### DIFF
--- a/cosmic/src/mlwind.f
+++ b/cosmic/src/mlwind.f
@@ -5,7 +5,7 @@
       integer kw,testflag
       real*8 lum,r,mt,mc,rl,z,teff,alpha
       real*8 dml,dms,dmt,p0,x,mew,lum0,kap
-      real*8 MLalpha, zsun_wind
+      real*8 MLalpha, zsun_wind, V
       external MLalpha
       parameter(lum0=7.0d+04,kap=-0.5d0)
 
@@ -25,7 +25,8 @@
 * Must be one of these values or mlwind will cause problem with code,
 * i.e. mlwind not set (see last line of main if statement...).
 
-      zsun_wind = 0.02
+*     defined solar Z for Vink winds
+      zsun_wind = 0.019
     
       if(windflag.eq.0)then
 * BSE
@@ -183,16 +184,24 @@
          if(teff.ge.12500.and.teff.le.25000)then
             if(eddlimflag.eq.0) alpha = 0.85d0
             if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
+*           ratio of terminal velocity to escape velocity
+            V = 1.3d0   !this is for cool side of galactic/solar Z
+            V = V* (z/zsun_wind)**0.13d0    !corrected for Z
+
             dms = -6.688d0 + 2.210d0*LOG10(lum/1.0d+05) -
-     &            1.339d0*LOG10(mt/30.d0) - 1.601d0*LOG10(1.3d0/2.d0) +
+     &            1.339d0*LOG10(mt/30.d0) - 1.601d0*LOG10(V/2.d0) +
      &            alpha*LOG10(z/zsun_wind) + 1.07d0*LOG10(teff/2.0d+04)
             dms = 10.d0**dms
             testflag = 2
-         elseif(teff.gt.25000.and.teff.le.50000)then
+         elseif(teff.gt.25000.)then
+*        Although Vink et al. formulae  are only defined until Teff=50000K,
+*        we follow the Dutch prescription of MESA, and extend to higher Teff
+            V = 2.6d0   !this is for hot side of galactic/solar Z,
+            V = V* (z/zsun_wind)**0.13d0    !corrected for Z
             if(eddlimflag.eq.0) alpha = 0.85d0
             if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
             dms = -6.697d0 + 2.194d0*LOG10(lum/1.0d+05) -
-     &            1.313d0*LOG10(mt/30.d0) - 1.226d0*LOG10(2.6d0/2.d0) +
+     &            1.313d0*LOG10(mt/30.d0) - 1.226d0*LOG10(V/2.d0) +
      &            alpha*LOG10(z/zsun_wind) +
      &            0.933d0*LOG10(teff/4.0d+04) -
      &            10.92d0*(LOG10(teff/4.0d+04)**2)

--- a/cosmic/src/mlwind.f
+++ b/cosmic/src/mlwind.f
@@ -5,7 +5,7 @@
       integer kw,testflag
       real*8 lum,r,mt,mc,rl,z,teff,alpha
       real*8 dml,dms,dmt,p0,x,mew,lum0,kap
-      real*8 MLalpha
+      real*8 MLalpha, zsun_wind
       external MLalpha
       parameter(lum0=7.0d+04,kap=-0.5d0)
 
@@ -24,6 +24,9 @@
 *      stars=3.
 * Must be one of these values or mlwind will cause problem with code,
 * i.e. mlwind not set (see last line of main if statement...).
+
+      zsun_wind = 0.02
+    
       if(windflag.eq.0)then
 * BSE
 *
@@ -36,7 +39,7 @@
             x = MIN(1.d0,(lum-4000.d0)/500.d0)
             dms = 9.6d-15*x*(r**0.81d0)*(lum**1.24d0)*(mt**0.16d0)
             alpha = 0.5d0
-            dms = dms*(z/zsun)**(alpha)
+            dms = dms*(z/zsun_wind)**(alpha)
          endif
          if(kw.ge.2.and.kw.le.9)then
 * 'Reimers' mass loss
@@ -95,7 +98,7 @@
             endif !or is it simply x = Min(1, lum/500)?
             dms = 9.6d-15*x*(r**0.81d0)*(lum**1.24d0)*(mt**0.16d0)
             alpha = 0.5d0
-            dms = dms*(z/zsun)**(alpha)
+            dms = dms*(z/zsun_wind)**(alpha)
          endif
          if(kw.ge.2.and.kw.le.9)then
 * 'Reimers' mass loss
@@ -154,7 +157,7 @@
             x = MIN(1.d0,(lum-4000.d0)/500.d0)
             dms = 9.6d-15*x*(r**0.81d0)*(lum**1.24d0)*(mt**0.16d0)
             alpha = 0.5d0
-            dms = dms*(z/zsun)**(alpha)
+            dms = dms*(z/zsun_wind)**(alpha)
             testflag = 1
          endif
          if(kw.ge.2.and.kw.le.6)then
@@ -182,7 +185,7 @@
             if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
             dms = -6.688d0 + 2.210d0*LOG10(lum/1.0d+05) -
      &            1.339d0*LOG10(mt/30.d0) - 1.601d0*LOG10(1.3d0/2.d0) +
-     &            alpha*LOG10(z/zsun) + 1.07d0*LOG10(teff/2.0d+04)
+     &            alpha*LOG10(z/zsun_wind) + 1.07d0*LOG10(teff/2.0d+04)
             dms = 10.d0**dms
             testflag = 2
          elseif(teff.gt.25000.and.teff.le.50000)then
@@ -190,7 +193,8 @@
             if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
             dms = -6.697d0 + 2.194d0*LOG10(lum/1.0d+05) -
      &            1.313d0*LOG10(mt/30.d0) - 1.226d0*LOG10(2.6d0/2.d0) +
-     &            alpha*LOG10(z/zsun) +0.933d0*LOG10(teff/4.0d+04) -
+     &            alpha*LOG10(z/zsun_wind) +
+     &            0.933d0*LOG10(teff/4.0d+04) -
      &            10.92d0*(LOG10(teff/4.0d+04)**2)
             dms = 10.d0**dms
             testflag = 2
@@ -204,7 +208,7 @@
             if(lum.gt.6.0d+05.and.x.gt.1.d0)then
                if(eddlimflag.eq.0) alpha = 0.d0
                if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
-               dms = 1.5d0*1.0d-04*((z/zsun)**alpha)
+               dms = 1.5d0*1.0d-04*((z/zsun_wind)**alpha)
                testflag = 3
             endif
          elseif(kw.ge.7.and.kw.le.9)then !WR (naked helium stars)
@@ -212,7 +216,7 @@
 * 10 (Yoon & Langer 2005), with Vink & de Koter (2005) metallicity dependence
             if(eddlimflag.eq.0) alpha = 0.86d0
             if(eddlimflag.eq.1) alpha = MLalpha(mt,lum,kw)
-            dms = 1.0d-13*(lum**1.5d0)*((z/zsun)**alpha)
+            dms = 1.0d-13*(lum**1.5d0)*((z/zsun_wind)**alpha)
             testflag = 4
          endif
 *

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -960,6 +960,13 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
 
     flag = "zsun"
     if flag in BSEDict.keys():
+        if BSEDict[flag] != 0.019:
+            warnings.warn(
+                "'{0:s}' is set to a different value than assumed in the mlwind "
+                "prescriptions (you set it to '{1:0.2f}' and in mlwind, zsun_wind=0.019)".format(
+                    flag, BSEDict[flag]
+                )
+            )
         if BSEDict[flag] <= 0:
             raise ValueError(
                 "'{0:s}' needs to be greater than 0 (you set it to '{1:0.2f}')".format(

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -305,7 +305,10 @@ sampling
 
 =======================  =====================================================
 ``zsun``                 Sets the metallicity of the Sun which primarily affects
-                         stellar winds.
+                         stellar winds. Note that our wind prescriptions apply a 
+                         fixed zsun parameter: zsun_wind = 0.019 because the wind 
+                         prescriptions are calibrated to this value as described in
+                         `Vink+2001. <https://ui.adsabs.harvard.edu/abs/2001A%26A...369..574V/abstract>`_
 
                          **zsun = 0.014** following `Asplund 2009 <https://ui.adsabs.harvard.edu/abs/2009ARA%26A..47..481A/abstract>`_
 =======================  =====================================================

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -145,7 +145,9 @@ pts3 = 0.02
 ;;; METALLICITY FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; specify the value for Solar metallicity, which primarily affects
-; winds in BSE
+; winds in BSE Note that our wind prescriptions apply a 
+; fixed zsun parameter: zsun_wind = 0.019 because the wind 
+; prescriptions are calibrated to this value as described in Vink+2001
 ; default = 0.014 (Asplund+2009)
 zsun = 0.014
 

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(name=DISTNAME,
       tests_require=tests_require,
       extras_require=extras_require,
       python_requires='>3.5, <4',
-      use_2to3=True,
+      use_2to3=False,
       classifiers=[
           'Development Status :: 4 - Beta',
           'Programming Language :: Python',


### PR DESCRIPTION
This pull request is for the following changes in mlwind.f.
1. I have added `zsun_wind` to differentiate it from the global `zsun` variable and have set its value to 0.019  as wind mass-loss rates have originally been scaled from this value (e.g., see Section 4 of Vink et al. 2001). 
2. As described in Section 8 of Vink et al. 2001, the ratio of terminal velocity to escape velocity is dependent on metallicity by a factor of 0.13. Thus, I have added the appropriate scaling factor. 
3. Following the Dutch wind prescription of MESA, I have extended the use of Vink winds beyond 50 000K.  This is only relevant for hot, very massive stars (M>150Msun), that have not yet reached the Eddington limit. Before this, winds from Nieuwenhuijzen & de Jager 1990 were getting used for such stars. 


 