### PR TITLE
Orbital sampling

### DIFF
--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -787,7 +787,7 @@ class Sample(object):
             log10_RL_porb = np.log10(RL_porb)
             log10_porb_min[log10_porb_min <  log10_RL_porb] = log10_RL_porb[log10_porb_min < log10_RL_porb]
             
-            porb = 10 ** (np.random.uniform(log_porb_min, log10_porb_max, size))
+            porb = 10 ** (np.random.uniform(log10_porb_min, log10_porb_max, size))
             (ind_massive,) = np.where(mass1 > 15)
             
             if type(log10_porb_max) != float:

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -767,13 +767,17 @@ class Sample(object):
             # hard/soft boundary or 5.5 (from Sana paper)
             if porb_max is None:
                 log10_porb_max = 5.5
+            
+            elif type(porb_max) != float:
+                log10_porb_max = np.minimum(5.5,np.log10(porb_max))
+                log10_porb_max = log10_porb_max[ind_massive]
             else:
                 log10_porb_max = np.minimum(5.5,np.log10(porb_max))
 
             porb = 10 ** (np.random.uniform(0.15, log10_porb_max, size))
             (ind_massive,) = np.where(mass1 > 15)
             porb[ind_massive] = 10 ** utils.rndm(
-                a=0.15, b=log10_porb_max[ind_massive], g=-0.55, size=len(ind_massive)
+                a=0.15, b=log10_porb_max, g=-0.55, size=len(ind_massive)
             )
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
         else:

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -781,7 +781,6 @@ class Sample(object):
             
             # Use the lower limit from the Sana12 distribution, unless this means the binaries are sampled at RL overflow. If so, 
             # change the lower limit to a_min
-                         
             log10_porb_min = np.array([0.15]*len(a_min)) 
             RL_porb = utils.p_from_a(a_min,mass1,mass2)
             log10_RL_porb = np.log10(RL_porb)
@@ -796,7 +795,7 @@ class Sample(object):
             
             
             porb[ind_massive] = 10 ** utils.rndm(
-                a=log10_porb_min, b=log10_porb_max, g=-0.55, size=len(ind_massive))
+                a=log10_porb_min[ind_massive], b=log10_porb_max, g=-0.55, size=len(ind_massive))
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
         else:
             raise ValueError(

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -768,17 +768,17 @@ class Sample(object):
             if porb_max is None:
                 log10_porb_max = 5.5
             
-            elif type(porb_max) != float:
-                log10_porb_max = np.minimum(5.5,np.log10(porb_max))
-                log10_porb_max = log10_porb_max[ind_massive]
             else:
                 log10_porb_max = np.minimum(5.5,np.log10(porb_max))
 
             porb = 10 ** (np.random.uniform(0.15, log10_porb_max, size))
             (ind_massive,) = np.where(mass1 > 15)
+            
+            if type(log10_porb_max) != float:
+                log10_porb_max = log10_porb_max[ind_massive]
+             
             porb[ind_massive] = 10 ** utils.rndm(
-                a=0.15, b=log10_porb_max, g=-0.55, size=len(ind_massive)
-            )
+                a=0.15, b=log10_porb_max, g=-0.55, size=len(ind_massive))
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
         else:
             raise ValueError(

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -773,7 +773,7 @@ class Sample(object):
             porb = 10 ** (np.random.uniform(0.15, log10_porb_max, size))
             (ind_massive,) = np.where(mass1 > 15)
             porb[ind_massive] = 10 ** utils.rndm(
-                a=0.15, b=log10_porb_max, g=-0.55, size=len(ind_massive)
+                a=0.15, b=log10_porb_max[ind_massive], g=-0.55, size=len(ind_massive)
             )
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
         else:

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -762,7 +762,7 @@ class Sample(object):
             # Use the lower limit from the Sana12 distribution, unless this means the binaries are sampled at RL overflow. If so, 
             # change the lower limit to a_min
                          
-            log10_porb_min = np.array([0.15]*len(log10_porb_max)) 
+            log10_porb_min = np.array([0.15]*len(a_min)) 
             RL_porb = utils.p_from_a(a_min,mass1,mass2)
             log10_RL_porb = np.log10(RL_porb)
             log10_porb_min[log10_porb_min <  log10_RL_porb] = log10_RL_porb[log10_porb_min < log10_RL_porb]
@@ -782,7 +782,7 @@ class Sample(object):
             # Use the lower limit from the Sana12 distribution, unless this means the binaries are sampled at RL overflow. If so, 
             # change the lower limit to a_min
                          
-            log10_porb_min = np.array([0.15]*len(log10_porb_max)) 
+            log10_porb_min = np.array([0.15]*len(a_min)) 
             RL_porb = utils.p_from_a(a_min,mass1,mass2)
             log10_RL_porb = np.log10(RL_porb)
             log10_porb_min[log10_porb_min <  log10_RL_porb] = log10_RL_porb[log10_porb_min < log10_RL_porb]

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -759,7 +759,15 @@ class Sample(object):
             else:
                 log10_porb_max = np.minimum(5.5,np.log10(porb_max))
 
-            porb = 10 ** utils.rndm(a=0.15, b=log10_porb_max, g=-0.55, size=size)
+            # Use the lower limit from the Sana12 distribution, unless this means the binaries are sampled at RL overflow. If so, 
+            # change the lower limit to a_min
+                         
+            log10_porb_min = np.array([0.15]*len(log10_porb_max)) 
+            RL_porb = utils.p_from_a(a_min,mass1,mass2)
+            log10_RL_porb = np.log10(RL_porb)
+            log10_porb_min[log10_porb_min <  log10_RL_porb] = log10_RL_porb[log10_porb_min < log10_RL_porb]
+            
+            porb = 10 ** utils.rndm(a=log10_porb_min, b=log10_porb_max, g=-0.55, size=size)
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
 
         elif porb_model == "renzo19":
@@ -770,15 +778,25 @@ class Sample(object):
             
             else:
                 log10_porb_max = np.minimum(5.5,np.log10(porb_max))
-
-            porb = 10 ** (np.random.uniform(0.15, log10_porb_max, size))
+            
+            # Use the lower limit from the Sana12 distribution, unless this means the binaries are sampled at RL overflow. If so, 
+            # change the lower limit to a_min
+                         
+            log10_porb_min = np.array([0.15]*len(log10_porb_max)) 
+            RL_porb = utils.p_from_a(a_min,mass1,mass2)
+            log10_RL_porb = np.log10(RL_porb)
+            log10_porb_min[log10_porb_min <  log10_RL_porb] = log10_RL_porb[log10_porb_min < log10_RL_porb]
+            
+            porb = 10 ** (np.random.uniform(log_porb_min, log10_porb_max, size))
             (ind_massive,) = np.where(mass1 > 15)
             
             if type(log10_porb_max) != float:
                 log10_porb_max = log10_porb_max[ind_massive]
-             
+                log10_porb_min = log10_porb_min[ind_massive]              
+            
+            
             porb[ind_massive] = 10 ** utils.rndm(
-                a=0.15, b=log10_porb_max, g=-0.55, size=len(ind_massive))
+                a=log10_porb_min, b=log10_porb_max, g=-0.55, size=len(ind_massive))
             aRL_over_a = a_min / utils.a_from_p(porb,mass1,mass2) 
         else:
             raise ValueError(
@@ -827,7 +845,10 @@ class Sample(object):
             return ecc
 
         elif ecc_model == "sana12":
-            ecc = utils.rndm(a=0.001, b=0.9, g=-0.45, size=size)
+            sana_max = np.array([0.9]*len(e_max))
+            max_e = np.minimum(e_max, sana_max)
+            ecc = utils.rndm(a=0.001, b=max_e, g=-0.45, size=size)
+            
             return ecc
 
         elif ecc_model == "circular":


### PR DESCRIPTION
Some binaries were being sampled at separations smaller than RL radius, causing them to merge immediately. To fix this, I added lines in the independent.py file that check if the orbital period sampled is less than the minimum orbital period for RL. If so, it replaces the value with the minimum RL separation. The same procedure is used for the sana12 and renzo19 samplers. For consistency, I also truncate the eccentricities to avoid RL overflow. For the sana12 eccentricity sampling, I set the maximum value to be either the sana12 value of 0.9 or the one corrected for RL, whichever is smaller.  