### PR TITLE
Implementing Eddington limit for BHs based on spinup/ISCO

### DIFF
--- a/cosmic/src/const_bse.h
+++ b/cosmic/src/const_bse.h
@@ -15,8 +15,7 @@
      &               htpmb,ST_cr,ST_tide,bdecayfac,grflag,
      &               bhms_coll_flag
       REAL*8 don_lim,acc_lim,Mbh_initial
-      INTEGER BHbirth_ind
-      COMMON /MTVARS/ don_lim,acc_lim,Mbh_initial,BHbirth_ind
+      COMMON /MTVARS/ don_lim,acc_lim,Mbh_initial
       INTEGER ceflag,cekickflag,cemergeflag,cehestarflag,ussn
       COMMON /CEFLAGS/ ceflag,cekickflag,cemergeflag,cehestarflag,ussn
       INTEGER pisn_track(2)

--- a/cosmic/src/const_bse.h
+++ b/cosmic/src/const_bse.h
@@ -14,8 +14,9 @@
      &               qcflag,eddlimflag,bhspinflag,aic,rejuvflag,
      &               htpmb,ST_cr,ST_tide,bdecayfac,grflag,
      &               bhms_coll_flag
-      REAL*8 don_lim,acc_lim
-      COMMON /MTVARS/ don_lim,acc_lim
+      REAL*8 don_lim,acc_lim,Mbh_initial
+      INTEGER BHbirth_ind
+      COMMON /MTVARS/ don_lim,acc_lim,Mbh_initial,BHbirth_ind
       INTEGER ceflag,cekickflag,cemergeflag,cehestarflag,ussn
       COMMON /CEFLAGS/ ceflag,cekickflag,cemergeflag,cehestarflag,ussn
       INTEGER pisn_track(2)

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -530,13 +530,13 @@ component.
             if(kstar(3-k).eq.14)then
                maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
                if(mass(3-k).lt.maxspinBH)then
-                  etaBH = (1 -
-     &       (1 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+                  etaBH = 1.d0 -
+     &    (1.d0 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0))**(1.d0/2.d0)
                else
                   etaBH = 0.42
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &       *(1.d0/etaBH)*rad(3-k)*tb
+     &    *(1.d0/etaBH)*rad(3-k)*tb
             endif
 
 *
@@ -1425,13 +1425,13 @@ component.
             if(kstar(k).eq.14)then
                maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
                if(mass(k).lt.maxspinBH)then
-                  etaBH = (1 -
-     &       (1 - (mass(k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+                  etaBH = 1.d0 -
+     &    (1.d0 - (mass(k)/(3.d0*Mbh_initial))**(2.d0))**(1.d0/2.d0)
                else
                   etaBH = 0.42
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &       *(1.d0/etaBH)*rad(k)*tb
+     &    *(1.d0/etaBH)*rad(k)*tb
             endif
             if(tphys-epoch(k).lt.tiny)then
                if(kstar(k).eq.13.and.pulsar.gt.0)then
@@ -1937,13 +1937,13 @@ component.
       if(kstar(j2).eq.14)then
          maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
          if(mass(j2).lt.maxspinBH)then
-            etaBH = (1 -
-     &       (1 - (mass(j2)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+            etaBH = 1.d0 -
+     &    (1.d0 - (mass(j2)/(3.d0*Mbh_initial))**(2.d0))**(1.d0/2.d0)
          else
             etaBH = 0.42
          endif
          dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &       *(1.d0/etaBH)*rad(j2)*tb
+     &    *(1.d0/etaBH)*rad(j2)*tb
       endif
 
       supedd = .false.
@@ -2655,13 +2655,13 @@ component.
             if(kstar(3-k).eq.14)then
                maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
                if(mass(3-k).lt.maxspinBH)then
-                  etaBH = (1 -
-     &       (1 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+                  etaBH = 1.d0 -
+     &    (1.d0 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0))**(1.d0/2.d0)
                else
                   etaBH = 0.42
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &       *(1.d0/etaBH)*rad(3-k)*tb
+     &    *(1.d0/etaBH)*rad(3-k)*tb
             endif
 
             if(neta.gt.tiny)then

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -271,7 +271,7 @@ Cf2py intent(out) kick_info_out
       ngtv2 = -2.d0
       twopi = 2.d0*ACOS(-1.d0)
 
-      BHbirth_ind = 0
+      Mbh_initial = 0.d0
 
 
 * disrupt tracks if system get disrupted by a SN during the common

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1417,10 +1417,22 @@ component.
 *
 *
 * Force new NS or BH to have a birth spin peirod and magnetic field.
-* 
+*
          if(kstar(k).eq.13.or.kstar(k).eq.14)then
 * re-calculate the Eddington limit of the newly formed CO
-            dme = 2.08d-03*eddfac*(1.d0/(1.d0 + zpars(11)))*rad(k)  
+            dme = 2.08d-03*eddfac*(1.d0/(1.d0 + zpars(11)))*rad(k)
+* For BHs, follow Marchant et al. 2017
+            if(kstar(k).eq.14)then
+               maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
+               if(mass(k).lt.maxspinBH)then
+                  etaBH = (1 -
+     &       (1 - (mass(k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+               else
+                  etaBH = 0.42
+               endif
+               dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
+     &       *(1.d0/etaBH)*rad(k)*tb
+            endif
             if(tphys-epoch(k).lt.tiny)then
                if(kstar(k).eq.13.and.pulsar.gt.0)then
 *                  write(93,*)'birth start: ',tphys,k,B_0(k),ospin(k)

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -185,6 +185,7 @@
       REAL*8 bhspin(2)
       REAL*8 delet,delet1,dspint(2),djspint(2),djtx(2)
       REAL*8 dtj,djorb,djgr,djmb,djt,djtt,rmin,rdisk
+      REAL*8 etaBH,maxspinBH
 *
       INTEGER pulsar
       INTEGER mergemsp,merge_mem,notamerger,binstate,mergertype
@@ -269,6 +270,8 @@ Cf2py intent(out) kick_info_out
       ngtv = -1.d0
       ngtv2 = -2.d0
       twopi = 2.d0*ACOS(-1.d0)
+
+      BHbirth_ind = 0
 
 
 * disrupt tracks if system get disrupted by a SN during the common
@@ -523,6 +526,18 @@ component.
 * Just in case the wind mass loss rates are *very* high
 *
             dme = 2.08d-03*eddfac*(1.d0/(1.d0 + zpars(11)))*rad(3-k)
+* For BHs, follow Marchant et al. 2017
+            if(kstar(3-k).eq.14)then
+               maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
+               if(mass(3-k).lt.maxspinBH)then
+                  etaBH = (1 -
+     &       (1 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+               else
+                  etaBH = 0.42
+               endif
+               dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
+     &       *(1.d0/etaBH)*rad(3-k)*tb
+            endif
 
 *
 * Calculate wind mass loss from the previous timestep.
@@ -1903,6 +1918,18 @@ component.
 * Eddington limit for accretion on to the secondary in one orbit.
 *
  8    dme = 2.08d-03*eddfac*(1.d0/(1.d0 + zpars(11)))*rad(j2)*tb
+* For BHs, follow Marchant et al. 2017
+      if(kstar(j2).eq.14)then
+         maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
+         if(mass(j2).lt.maxspinBH)then
+            etaBH = (1 -
+     &       (1 - (mass(j2)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+         else
+            etaBH = 0.42
+         endif
+         dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
+     &       *(1.d0/etaBH)*rad(j2)*tb
+      endif
       supedd = .false.
       novae = .false.
       disk = .false.
@@ -2608,6 +2635,18 @@ component.
 * Just in case the wind mass loss rates are *very* high
 *
             dme = 2.08d-03*eddfac*(1.d0/(1.d0 + zpars(11)))*rad(3-k)*tb
+* For BHs, follow Marchant et al. 2017
+            if(kstar(3-k).eq.14)then
+               maxspinBH = 6.d0**(1.d0/2.d0) * Mbh_initial
+               if(mass(3-k).lt.maxspinBH)then
+                  etaBH = (1 -
+     &       (1 - (mass(3-k)/(3.d0*Mbh_initial))**(2.d0)))**(1.d0/2.d0)
+               else
+                  etaBH = 0.42
+               endif
+               dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
+     &       *(1.d0/etaBH)*rad(3-k)*tb
+            endif
 
             if(neta.gt.tiny)then
                if(beta.lt.0.d0)then !PK. following startrack

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -536,7 +536,7 @@ component.
                   etaBH = 0.42
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &    *(1.d0/etaBH)*rad(3-k)*tb
+     &    *(1.d0/etaBH)*rad(3-k)
             endif
 
 *
@@ -1431,7 +1431,8 @@ component.
                   etaBH = 0.42
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
-     &    *(1.d0/etaBH)*rad(k)*tb
+     &    *(1.d0/etaBH)*rad(k)
+               WRITE(*,*)'test:',etaBH,dme,Mbh_initial,mass(k)
             endif
             if(tphys-epoch(k).lt.tiny)then
                if(kstar(k).eq.13.and.pulsar.gt.0)then

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1432,7 +1432,6 @@ component.
                endif
                dme = 1.04e-3*eddfac*(1.d0/(1.d0 + zpars(11)))
      &    *(1.d0/etaBH)*rad(k)
-               WRITE(*,*)'test:',etaBH,dme,Mbh_initial,mass(k)
             endif
             if(tphys-epoch(k).lt.tiny)then
                if(kstar(k).eq.13.and.pulsar.gt.0)then

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -803,7 +803,6 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Store the initial BH mass for calculating the ISCO later
                      if(BHbirth_ind.eq.0)then
                         Mbh_initial = mt
-                        WRITE(*,*) Mbh_initial
                         BHbirth_ind = 1
                      endif
                   endif
@@ -1185,7 +1184,6 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Store the initial BH mass for calculating the ISCO later
                      if(BHbirth_ind.eq.0)then
                         Mbh_initial = mt
-                        WRITE(*,*) Mbh_initial
                         BHbirth_ind = 1
                      endif
                      endif
@@ -1285,7 +1283,6 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Store the initial BH mass for calculating the ISCO later
          if(BHbirth_ind.eq.0)then
             Mbh_initial = mt
-            WRITE(*,*) Mbh_initial
             BHbirth_ind = 1
          endif
          lum = 1.0d-10

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -800,6 +800,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                         endif
                      endif
                      mt = mrem
+* Store the initial BH mass for calculating the ISCO later
+                     if(BHbirth_ind.eq.0)then
+                        Mbh_initial = mt
+                        WRITE(*,*) Mbh_initial
+                        BHbirth_ind = 1
+                     endif
                   endif
                endif
             endif
@@ -1176,7 +1182,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                         endif
                      endif
                      mt = mrem
-
+* Store the initial BH mass for calculating the ISCO later
+                     if(BHbirth_ind.eq.0)then
+                        Mbh_initial = mt
+                        WRITE(*,*) Mbh_initial
+                        BHbirth_ind = 1
+                     endif
                      endif
                   endif
                endif
@@ -1271,6 +1282,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 *        Black hole
 *
          mc = mt
+* Store the initial BH mass for calculating the ISCO later
+         if(BHbirth_ind.eq.0)then
+            Mbh_initial = mt
+            WRITE(*,*) Mbh_initial
+            BHbirth_ind = 1
+         endif
          lum = 1.0d-10
          r = 4.24d-06*mt
       endif

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -801,9 +801,8 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      endif
                      mt = mrem
 * Store the initial BH mass for calculating the ISCO later
-                     if(BHbirth_ind.eq.0)then
+                     if(Mbh_initial.eq.0)then
                         Mbh_initial = mt
-                        BHbirth_ind = 1
                      endif
                   endif
                endif
@@ -1182,9 +1181,8 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      endif
                      mt = mrem
 * Store the initial BH mass for calculating the ISCO later
-                     if(BHbirth_ind.eq.0)then
+                     if(Mbh_initial.eq.0)then
                         Mbh_initial = mt
-                        BHbirth_ind = 1
                      endif
                      endif
                   endif
@@ -1281,9 +1279,8 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 *
          mc = mt
 * Store the initial BH mass for calculating the ISCO later
-         if(BHbirth_ind.eq.0)then
+         if(Mbh_initial.eq.0)then
             Mbh_initial = mt
-            BHbirth_ind = 1
          endif
          lum = 1.0d-10
          r = 4.24d-06*mt


### PR DESCRIPTION
This PR adjusts the Eddington limit for BHs based on the implementation in [Marchant et al. 2017](https://ui.adsabs.harvard.edu/abs/2017A%26A...604A..55M/abstract), following Equations 3-5. It introduces a new global parameter `Mbh_initial` that remembers the initial mass of the BH at formation, and calculates the `eta` parameter that alters the mass transfer rate based on where the ISCO is, assuming the BH is spinning up from stable accretion as in [Thorne 1970](https://ui.adsabs.harvard.edu/abs/1974ApJ...191..507T/abstract). 

As of now, I added an additional global parameter `BHbirth_ind` that is 0 before the BH forms and 1 after so that `Mbh_initial` doesn't get overwritten in `hrdiag.f`, though there's probably a more glamorous way to ensure this. 

This actually causes the Eddington limit for BHs to be ~1 order of magnitude higher for low-spinning BHs than the standard BSE prescription!!! It is unclear where Hurley got the expression for the Eddington limit that is implemented in stock BSE (Equation 67 of [Hurley et al. 2002](https://ui.adsabs.harvard.edu/abs/2002MNRAS.329..897H/abstract)). The two expressions are identical for `eta =  0.5`, which is slightly above the maximum value of `eta=0.42` which is attained for a maximally-spinning BH (one that accreted more than sqrt(6) times its initial mass). 

Attached are the mass transfer rates for a few binaries, comparing the current BH accretion limit to the one in this PR. There is still an issue of deltam_1 for the first timestep written into the bcm array not obeying the imposed Eddington limit, which can be seen in a few of these systems. 

![eddlim](https://user-images.githubusercontent.com/11998670/187975498-71915f33-57a9-416f-abaf-c944635c0e1a.png)

There are probably other changes that need to be made to the unit test files, so let me know what else needs to be done!