### PR TITLE
nan radius fixes

### DIFF
--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -1169,7 +1169,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      else
 * If rembar_massloss >= 0, limit the massloss by rembar_massloss
                         if(rembar_massloss.ge.0d0)then
-                           mrem = mt-rembar_massloss
+                           if(mt.ge.rembar_massloss)then
+                                mrem = mt-rembar_massloss
+                           else
+                                mrem = 0
+                           endif
+
 * If -1 < rembar_massloss < 0, assume this fractional mass loss
                         else
                            mrem = (1.d0+rembar_massloss)*mt


### PR DESCRIPTION
I was getting nan radii for rare systems where a system of massive stars undergo common envelope and one of the stars undergoes a PISN. Then, that object is assigned a current mass value of mt = 0, which results in a negative remnant mass value in line 1175 of the hrdiag.f file. To fix this, I propose to add an additional if statement that first checks if the rembar-massloss value is greater than mt to avoid a negative mrem value. 

