### PR TITLE
Hardcoded zsun for winds plus other bug fixes following Gaia BH project

### DIFF
--- a/cosmic/sample/initialcmctable.py
+++ b/cosmic/sample/initialcmctable.py
@@ -308,8 +308,8 @@ class InitialCMCTable(pd.DataFrame):
         singles_bottom = pd.DataFrame(
             np.zeros((1, Singles.shape[1])), index=[0], columns=Singles.columns
         )
-        singles = singles.append(Singles)
-        singles = singles.append(singles_bottom)
+        singles = pd.concat([singles, Singles])
+        singles = pd.concat([singles, singles_bottom])
         singles["r"].iloc[-1] = 1e40
         singles["r"].iloc[0] = 2.2250738585072014e-308
 
@@ -317,7 +317,7 @@ class InitialCMCTable(pd.DataFrame):
         binaries = pd.DataFrame(
             np.zeros((1, Binaries.shape[1])), index=[0], columns=Binaries.columns
         )
-        binaries = binaries.append(Binaries)
+        binaries = pd.concat([binaries, Binaries])
 
         if savehdf5:
             singles.to_hdf(filename, key="CLUS_OBJ_DATA", mode="w")

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -21,6 +21,7 @@
 
 import numpy as np
 import warnings
+import pandas as pd
 
 from ... import utils
 

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -263,7 +263,7 @@ def get_independent_sampler(
             np.ones_like(mass1_singles)*0,
             metallicity,
         )
-        binary_table = binary_table.append(singles_table)
+        binary_table = pd.concat([binary_table, singles_table])
     else:
         binary_table = InitialBinaryTable.InitialBinaries(
             mass1_binary,

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -540,7 +540,8 @@ component.
 *
 * Calculate wind mass loss from the previous timestep.
 *
-            if(neta.gt.tiny)then
+            !check for kstar added by PA
+            if(neta.gt.tiny .and. kstar(k)<15)then
                rlperi = rol(k)*(1.d0-ecc)
                dmr(k) = mlwind(kstar(k),lumin(k),rad(k),mass(k),
      &                         massc(k),rlperi,z)
@@ -591,7 +592,8 @@ component.
 *
 * Diagnostic for Symbiotic-type stars.
 *
-         if(neta.gt.tiny)then
+         !check for kstar added by PA
+         if(neta.gt.tiny .and. kstar(j2)<15)then
             lacc = 3.14d+07*mass(j2)*dmt(j2)/rad(j2)
             lacc = lacc/lumin(j1)
          endif
@@ -849,7 +851,8 @@ component.
      &                 (3.d0*lumin(k)))**(1.d0/3.d0)
                   ttid = twopi/(1.0d-10 + ABS(oorb - ospin(k)))
                   f = MIN(1.d0,(ttid/(2.d0*tc))**2)
-                  tcqr = fprimc_array(kstar(k))*
+                  !kstar(k) to kstar(k)+1 by PA for kstar(k)=0
+                  tcqr = fprimc_array(kstar(k)+1)*
      &                 f*q(3-k)*raa6*menv(k)/
      &                 (tc*mass(k))
                   rg2 = (k2str(k)*(mass(k)-massc(k)))/mass(k)
@@ -903,7 +906,8 @@ component.
 *
       elseif(ABS(dtm).gt.tiny.and.sgl)then
          do 503 , k = kmin,kmax
-            if(neta.gt.tiny)then
+            !check for kstar added by PA
+            if(neta.gt.tiny .and. kstar(k)<15)then
                rlperi = 0.d0
                dmr(k) = mlwind(kstar(k),lumin(k),rad(k),mass(k),
      &                         massc(k),rlperi,z)
@@ -1330,7 +1334,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2))
                CALL kick(kw,mass(k),mt,0.d0,0.d0,-1.d0,0.d0,vk,k,
-     &                  0.d0,fallback,sigmahold,kick_info,disrupt,bkick)     
+     &                  0.d0,fallback,sigmahold,kick_info,disrupt,bkick)
 
                sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
 * set kick values for the bcm array
@@ -2661,7 +2665,8 @@ component.
      &    *(1.d0/etaBH)*rad(3-k)*tb
             endif
 
-            if(neta.gt.tiny)then
+            !check for kstar added by PA
+            if(neta.gt.tiny .and. kstar(k)<15)then
                if(beta.lt.0.d0)then !PK. following startrack
                   beta = 0.125
                   if(kstar(k).le.1)then
@@ -3278,7 +3283,8 @@ component.
      &                 (3.d0*lumin(k)))**(1.d0/3.d0)
                   ttid = twopi/(1.0d-10 + ABS(oorb - ospin(k)))
                   f = MIN(1.d0,(ttid/(2.d0*tc))**2)
-                  tcqr = fprimc_array(kstar(k))*
+                  !kstar(k) to kstar(k)+1 by PA for kstar(k)=0
+                  tcqr = fprimc_array(kstar(k)+1)*
      &                 f*q(3-k)*raa6*menv(k)/
      &                 (tc*mass(k))
                   rg2 = (k2str(k)*(mass(k)-massc(k)))/mass(k)
@@ -3703,7 +3709,7 @@ component.
 
 *
 * Test whether the primary still fills its Roche lobe.
-*  
+*
       if(rad(j1).gt.rol(j1).and..not.snova)then
 *
 * Test for a contact system
@@ -4244,6 +4250,44 @@ component.
           mass1_bpp = mass(1)
           mass2_bpp = mass(2)
 
+          !added by PA for systems that manage to reach here
+          !without encountering write bpp at all
+          if (jp<1) then
+              evolve_type = 1.d0
+              rrl1 = rad(1)/rol(1)
+              rrl2 = rad(2)/rol(2)
+              teff1 = 1000.d0*((1130.d0*lumin(1)/
+     &                       (rad(1)**2.d0))**(1.d0/4.d0))
+              teff2 = 1000.d0*((1130.d0*lumin(2)/
+     &                       (rad(2)**2.d0))**(1.d0/4.d0))
+              if(B_0(1).eq.0.d0)then !PK.
+                 b01_bcm = 0.d0
+              elseif(B_0(1).gt.0.d0.and.B(1).eq.0.d0)then
+                 b01_bcm = B_0(1)
+              else
+                 b01_bcm = B(1)
+              endif
+              if(B_0(2).eq.0.d0)then
+                 b02_bcm = 0.d0
+              elseif(B_0(2).gt.0.d0.and.B(2).eq.0.d0)then
+                 b02_bcm = B_0(2)
+              else
+                 b02_bcm = B(2)
+              endif
+
+              CALL writebpp(jp,tphys,evolve_type,
+     &                  mass(1),mass(2),kstar(1),kstar(2),sep,
+     &                  tb,ecc,rrl1,rrl2,
+     &                  aj(1),aj(2),tms(1),tms(2),
+     &                  massc(1),massc(2),rad(1),rad(2),
+     &                  mass0(1),mass0(2),lumin(1),lumin(2),
+     &                  teff1,teff2,radc(1),radc(2),
+     &                  menv(1),menv(2),renv(1),renv(2),
+     &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                  epoch(2),bhspin(1),bhspin(2))
+          endif
+          
           if(kstar(1).eq.15.and.bpp(jp,4).lt.15.0)then
               mass1_bpp = mass0(1)
           endif
@@ -4251,7 +4295,7 @@ component.
           if(kstar(2).eq.15.and.bpp(jp,5).lt.15.0)then
               mass2_bpp = mass0(2)
           endif
-
+          
           if(coel)then
               evolve_type = 6.0
               teff1 = 1000.d0*((1130.d0*lumin(1)/
@@ -4322,6 +4366,8 @@ component.
      &                      epoch(2),bhspin(1),bhspin(2))
           else
               evolve_type = 10.0
+              !added by PA for systems that stop evolving halfway
+              if(iter.ge.loop) evolve_type = 100.0
               rrl1 = rad(1)/rol(1)
               rrl2 = rad(2)/rol(2)
               teff1 = 1000.d0*((1130.d0*lumin(1)/
@@ -4422,7 +4468,6 @@ component.
  145        continue
          endif
 *
-
       elseif((kstar(1).eq.15.and.kstar(2).eq.15))then
          tphys = tphysf
          evolve_type = 10.0

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -1286,6 +1286,17 @@ C      if(mt0.gt.100.d0) mt = 100.d0
          r = 4.24d-06*mt
       endif
 *
+      !added by PA
+      if(kw .eq.15) then
+*
+*         Massless remnant
+*
+          aj = 0.d0
+          mt = 0.d0
+          lum = 1.0d-10
+          r = 1.0d-10
+      endif
+*
 * Calculate the core radius and the luminosity and radius of the
 * remnant that the star will become.
 *

--- a/cosmic/tests/test_evolve.py
+++ b/cosmic/tests/test_evolve.py
@@ -13,6 +13,9 @@ from ..sample.initialbinarytable import InitialBinaryTable
 from ..sample import initialbinarytable
 from .. import evolve
 
+import warnings
+warnings.filterwarnings("ignore")
+
 TEST_DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 PARAMS_INI = os.path.join(TEST_DATA_DIR,'Params.ini')
 INIT_CONDITIONS = pd.read_hdf(os.path.join(TEST_DATA_DIR, 'initial_conditions_for_testing.hdf5'), key='initC')
@@ -43,55 +46,55 @@ class TestEvolve(unittest.TestCase):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS, randomseed=523574)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_single_evolve_with_dict(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS_NO_BSE_COLUMNS, BSEDict=BSEDict, randomseed=523574)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_single_evolve_with_inifile(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS_NO_BSE_COLUMNS, params=PARAMS_INI, randomseed=523574)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_single_evolve_with_dict_and_table(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS, BSEDict=BSEDict, randomseed=523574)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_multi_evolve_with_table(self):
         # Check that the sample_primary function samples mass correctly
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS, n_per_block=100)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_multi_evolve_with_dict(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS_NO_BSE_COLUMNS, BSEDict=BSEDict, randomseed=523574, n_per_block=100)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_multi_evolve_with_inifile(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS_NO_BSE_COLUMNS, params=PARAMS_INI, randomseed=523574, n_per_block=100)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)
 
     def test_multi_evolve_with_dict_and_table(self):
         EvolvedBinaryBPP, EvolvedBinaryBCM, initCond, kick_info = Evolve.evolve(
             initialbinarytable=INIT_CONDITIONS, BSEDict=BSEDict, randomseed=523574, n_per_block=100)
 
-        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False, check_less_precise=True)
-        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False, check_less_precise=True)
+        pd.testing.assert_frame_equal(EvolvedBinaryBPP, BPP_DF, check_dtype=False, check_exact=False)
+        pd.testing.assert_frame_equal(EvolvedBinaryBCM, BCM_DF, check_dtype=False, check_exact=False)

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -1514,6 +1514,7 @@ def convert_kstar_evol_type(bpp):
         14: "blue straggler",
         15: "supernova of primary",
         16: "supernova of secondary",
+       100: "RLOF interpolation timeout error"
     }
 
     evolve_type_string_to_int_dict = {

--- a/docs/output_info/index.rst
+++ b/docs/output_info/index.rst
@@ -61,6 +61,7 @@ The evolutionary changes of the binary are logged in the evol_type column, which
     14          blue straggler
     15          supernova of primary
     16          supernova of secondary
+    100         RLOF interpolation timeout error
     =========   =====================
 
 


### PR DESCRIPTION
This PR includes modifications/bug fixes in cosmic from the Gaia BH project.

1. To avoid accretion of matter from a massless companion, the calculation of mass changes in evolv2.f now excludes type 15 stars.  The error results from non-zero 'dme' and the fact that the minimum of NaN (which is 'dmt') and dme gives me, leading to non-zero 'dmt' .

2. The properties of massless remnants are now exclusively assigned in hrdiag.f, so that they do not interfere with the evolution of other stars (e.g. due to non-neglible radii).

3. Added a new evolve_type (100) to identify systems that fail to evolve due to iter>loop error. 

4. Following the use of qcrit, replaced kstar(k) to kstar(k)+1 by PA to avoid errors for type 0 stars.

5. Added an extra call to write bpp array for systems that become remnant on entering evolv2.f ( mostly systems whose evolution has been restarted), and avoid write bpp array altogether, leading to issues later in the code. 

6. (Note that Gaia BH project did not have this.) Wind calculation should use original zsun values from their respective wind prescription and not depend on the zsun elsewhere in the code. The value is hardcoded to avoid misuse of zsun in mlwind.f. 
