### PR TITLE
Quick fix for deprecation due to incompatibility with Pandas >= 2.0.0 updated API

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/u77526sm/anaconda3/envs/cosmic_test/bin/python3.10
 
 # Code: cosmic-pop.py
 # Version: 1
@@ -443,7 +443,10 @@ if __name__ == '__main__':
             conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
 
         if len(conv_filter_match) >= np.min([50, args.Niter]):
-            conv_save = conv_save.append(conv_filter_match)
+            if pd.__version__<="2.0.0":
+                conv_save = conv_save.append(conv_filter_match)
+            else:
+                conv_save = pd.concat([conv_save, pd.DataFrame(conv_filter_match)], ignore_index=True)
 
             # perform the convergence
             if len(conv_save) == len(conv_filter_match):

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -445,7 +445,7 @@ if __name__ == '__main__':
                 kick_info_filter_match = kick_info_filter_match.append(kick_info_filter)
                 conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
             else:
-                bcm_filter_match = pd.concat(bcm_filter_match,bcm_filter), ignore_index=True)
+                bcm_filter_match = pd.concat(bcm_filter_match,bcm_filter, ignore_index=True)
                 bpp_filter_match = pd.concat(bpp_filter_match,bpp_filter, ignore_index=True)
                 initC_filter_match = pd.concat(initC_filter_match,initC_filter, ignore_index=True)
                 kick_info_filter_match = pd.concat(kick_info_filter_match,kick_info_filter, ignore_index=True)

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -379,7 +379,10 @@ if __name__ == '__main__':
         if nans.any():
             nan_bin_nums = np.unique(bpp[nans]["bin_num"].values)
             initCond_nan = initCond.loc[initCond.bin_num.isin(nan_bin_nums)]
-            dat_store.append("nan_initC", initCond_nan)
+            if pd.__version__<="2.0.0":
+                dat_store.append("nan_initC", initCond_nan)
+            else:
+                dat_store["nan_initC"] = initCond_nan
             log_file.write(f"There are {len(nan_bin_nums)} NaNs stored in the datfile with key: 'nan_initC'")
             log_file.write(f"These NaNs likely arise because you have pts1 = 0.001, try running with pts1 = 0.01")
 
@@ -435,11 +438,19 @@ if __name__ == '__main__':
             conv_filter_match = conv_filter.copy()
             kick_info_filter_match = kick_info_filter.copy()
         else:
-            bcm_filter_match = bcm_filter_match.append(bcm_filter)
-            bpp_filter_match = bpp_filter_match.append(bpp_filter)
-            initC_filter_match = initC_filter_match.append(initC_filter)
-            kick_info_filter_match = kick_info_filter_match.append(kick_info_filter)
-            conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
+            if pd.__version__<="2.0.0":
+                bcm_filter_match = bcm_filter_match.append(bcm_filter)
+                bpp_filter_match = bpp_filter_match.append(bpp_filter)
+                initC_filter_match = initC_filter_match.append(initC_filter)
+                kick_info_filter_match = kick_info_filter_match.append(kick_info_filter)
+                conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
+            else:
+                bcm_filter_match = pd.concat(bcm_filter_match,bcm_filter))
+                bpp_filter_match = pd.concat(bpp_filter_match,bpp_filter)
+                initC_filter_match = pd.concat(initC_filter_match,initC_filter)
+                kick_info_filter_match = pd.concat(kick_info_filter_match,kick_info_filter)
+                conv_filter_match = pd.concat(conv_filter_match,conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
+                
 
         if len(conv_filter_match) >= np.min([50, args.Niter]):
             if pd.__version__<="2.0.0":

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -445,11 +445,11 @@ if __name__ == '__main__':
                 kick_info_filter_match = kick_info_filter_match.append(kick_info_filter)
                 conv_filter_match = conv_filter_match.append(conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
             else:
-                bcm_filter_match = pd.concat(bcm_filter_match,bcm_filter))
-                bpp_filter_match = pd.concat(bpp_filter_match,bpp_filter)
-                initC_filter_match = pd.concat(initC_filter_match,initC_filter)
-                kick_info_filter_match = pd.concat(kick_info_filter_match,kick_info_filter)
-                conv_filter_match = pd.concat(conv_filter_match,conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)])
+                bcm_filter_match = pd.concat(bcm_filter_match,bcm_filter), ignore_index=True)
+                bpp_filter_match = pd.concat(bpp_filter_match,bpp_filter, ignore_index=True)
+                initC_filter_match = pd.concat(initC_filter_match,initC_filter, ignore_index=True)
+                kick_info_filter_match = pd.concat(kick_info_filter_match,kick_info_filter, ignore_index=True)
+                conv_filter_match = pd.concat(conv_filter_match,conv_filter.loc[conv_filter.bin_num.isin(conv_lims_bin_num)], ignore_index=True)
                 
 
         if len(conv_filter_match) >= np.min([50, args.Niter]):

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -1,5 +1,4 @@
-#!/home/u77526sm/anaconda3/envs/cosmic_test/bin/python3.10
-
+#!/usr/bin/env python
 # Code: cosmic-pop.py
 # Version: 1
 # Version changes: SAMPLE FIXED POPULATION OF BINARIES AND EVOLVE WITH BSE;


### PR DESCRIPTION
df.append has become deprecated in pandas versions >2.0.0 (latest == 2.0.3). This was preventing COSMIC from stacking tables and would cause it to return errors if the local pandas installation was incompatible (newer). Other .append (lines 382, 438-442,) methods will need to be replaced or worked around in a similar fashion to ensure compatibility going forward with future versions of pandas.
