### PR TITLE
Small fix for divide by zero warnings for single stars

### DIFF
--- a/cosmic/tests/test_utils.py
+++ b/cosmic/tests/test_utils.py
@@ -4,6 +4,9 @@
 __author__ = 'Katie Breivik <katie.breivik@gmail.com>'
 
 from ..sample import InitialBinaryTable
+from ..evolve import Evolve
+
+import warnings
 
 import os
 import unittest
@@ -154,6 +157,38 @@ class TestUtils(unittest.TestCase):
     def test_warning_check(self):
         with pytest.warns(UserWarning, match='At least one of your initial binaries is starting in Roche Lobe Overflow'):
             utils.check_initial_conditions(IBT)
+
+    def test_no_RL_check_for_singles(self):
+        """Make sure you don't get a divide by zero error when checking for Roche Lobe Overflow"""
+        BSEDict = {'xi': 1.0, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 1, 'alpha1': 1.0,
+                   'pts1': 0.001, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 0.5,
+                   'ck': 1000, 'bwind': 0.0, 'lambdaf': 0.0, 'mxns': 3.0, 'beta': -1.0, 'tflag': 1,
+                   'acc2': 1.5, 'grflag': 1, 'remnantflag': 4, 'ceflag': 0, 'eddfac': 1.0,
+                   'ifflag': 0, 'bconst': 3000, 'sigma': 265.0, 'gamma': -2.0, 'pisn': 45.0,
+                   'natal_kick_array': [[-100.0, -100.0, -100.0, -100.0, 0.0],
+                                        [-100.0, -100.0, -100.0, -100.0, 0.0]], 'bhsigmafrac': 1.0,
+                   'polar_kick_angle': 90, 'qcrit_array': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                                           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                   'cekickflag': 2, 'cehestarflag': 0, 'cemergeflag': 0, 'ecsn': 2.25,
+                   'ecsn_mlow': 1.6, 'aic': 1, 'ussn': 0, 'sigmadiv': -20.0, 'qcflag': 5,
+                   'eddlimflag': 0, 'fprimc_array': [2.0/21.0, 2.0/21.0, 2.0/21.0, 2.0/21.0,
+                                                     2.0/21.0, 2.0/21.0, 2.0/21.0, 2.0/21.0,
+                                                     2.0/21.0, 2.0/21.0, 2.0/21.0, 2.0/21.0,
+                                                     2.0/21.0, 2.0/21.0, 2.0/21.0, 2.0/21.0],
+                   'bhspinflag': 0, 'bhspinmag': 0.0, 'rejuv_fac': 1.0, 'rejuvflag': 0, 'htpmb': 1,
+                   'ST_cr': 1, 'ST_tide': 1, 'bdecayfac': 1, 'rembar_massloss': 0.5, 'kickflag': 0,
+                   'zsun': 0.014, 'bhms_coll_flag': 0, 'don_lim': -1, 'acc_lim': -1,
+                   'rtmsflag': 0}
+
+        initial_binaries = InitialBinaryTable.sampler('independent', np.linspace(0, 15, 16), np.linspace(0, 15, 16),
+                                                    binfrac_model=0.5, SF_start=10.0,
+                                                    SF_duration=0.0, met=0.02, size=10,
+                                                    primary_model='kroupa01', ecc_model='sana12', porb_model='sana12',
+                                                    keep_singles=True)[0]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Evolve.evolve(initialbinarytable=initial_binaries, BSEDict=BSEDict)
 
     def test_convert_kstar_evol_type(self):
         # convert to string

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -1579,7 +1579,7 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
     return
 
 
-def check_initial_conditions(initial_binary_table):
+def check_initial_conditions(full_initial_binary_table):
     """Checks initial conditions and reports warnings
 
     Only warning provided right now is if star begins in Roche lobe
@@ -1598,6 +1598,11 @@ def check_initial_conditions(initial_binary_table):
         ) / (a[12] + a[13] * m ** 2 + (a[14] * m ** 8 + m ** 18 + a[15] * m ** 19) * mx)
 
         return rzams
+
+    no_singles = ((full_initial_binary_table["mass_1"] > 0.0)
+                  & (full_initial_binary_table["mass_2"] > 0.0)
+                  & (full_initial_binary_table["porb"] > 0.0))
+    initial_binary_table = full_initial_binary_table[no_singles]
 
     z = np.asarray(initial_binary_table["metallicity"])
     zpars, a = zcnsts(z)


### PR DESCRIPTION
I changed the initial condition check to avoid single stars when calculating Roche Lobes (since the mass is zero)

This will fix #604 