### PR TITLE
added the necessary updates for including a central_bh in CMC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,3 +38,4 @@ See the discussed changes in our previous releases here: https://github.com/COSM
  - Bug fixes: `timestep_conditions` for `bcm` arrays now raise errors for invalid columns instead of failing silently
  - Add `teff_1` and `teff_2` as variables that can be used to set `timestep_conditions`
  - Add in `-1` option to turn off Magnetic Braking in htmb 
+ - Added `central_bh` and `scale_with_central_bh` as options to the CMC sampler, in order to add central massive black holes to CMC initial conditions


### PR DESCRIPTION
work from Tomás and me on including central massive black holes (MBHs) in CMC.

This places an MBH at the 0 index of the Singles array.  When using the regular CMC sampler the mass is specified in solar masses; when using the cmc-point-mass sampler the mass is specified in number of stars (e.g. for a 10,000 point-mass cluster, central_bh=1000 yields an MBH with 10% of the cluster mass).

There's an additional parameter, scale_with_central_bh, which can be passed to the sampler; if True, this adds the MBH potential energy into the calculation when rescaling the stellar positions (default is False).

finally, added a ``seed'' parameter to cmc_point_mass to create different point-mass realizations of clusters.