### PR TITLE
Added compression options for pandas

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -119,6 +119,10 @@ def parse_commandline():
     parser.add_argument("--seed", type=int)
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")
+    parser.add_argument("--complib",type=str,default="zlib",
+        help="HDFStore compression library")
+    parser.add_argument("--complevel",type=int,default=0,
+        help="HDFStore compression level")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-n", "--nproc",
@@ -232,7 +236,7 @@ if __name__ == '__main__':
 
     # Open the hdf5 file to store the fixed population data
     try:
-        dat_store = pd.HDFStore('dat_kstar1_{0}_kstar2_{1}_SFstart_{2}_SFduration_{3}_metallicity_{4}.h5'.format(kstar1_range_string, kstar2_range_string, sampling['SF_start'], sampling['SF_duration'], sampling['metallicity']))
+        dat_store = pd.HDFStore('dat_kstar1_{0}_kstar2_{1}_SFstart_{2}_SFduration_{3}_metallicity_{4}.h5'.format(kstar1_range_string, kstar2_range_string, sampling['SF_start'], sampling['SF_duration'], sampling['metallicity']),complib=args.complib,complevel=args.complevel)
         conv_save = pd.read_hdf(dat_store, 'conv')
         log_file = open('log_kstar1_{0}_kstar2_{1}_SFstart_{2}_SFduration_{3}_metallicity_{4}.txt'.format(kstar1_range_string, kstar2_range_string, sampling['SF_start'], sampling['SF_duration'], sampling['metallicity']), 'a')
         log_file.write('There are already: '+str(conv_save.shape[0])+' '+kstar1_range_string+'_'+kstar2_range_string+' binaries evolved\n')
@@ -246,7 +250,7 @@ if __name__ == '__main__':
         idx = int(np.max(pd.read_hdf(dat_store, 'idx'))[0])
     except:
         conv_save = pd.DataFrame()
-        dat_store = pd.HDFStore('dat_kstar1_{0}_kstar2_{1}_SFstart_{2}_SFduration_{3}_metallicity_{4}.h5'.format(kstar1_range_string, kstar2_range_string, sampling['SF_start'], sampling['SF_duration'], sampling['metallicity']))
+        dat_store = pd.HDFStore('dat_kstar1_{0}_kstar2_{1}_SFstart_{2}_SFduration_{3}_metallicity_{4}.h5'.format(kstar1_range_string, kstar2_range_string, sampling['SF_start'], sampling['SF_duration'], sampling['metallicity']),complib=args.complib,complevel=args.complevel)
         total_mass_singles = 0  
         total_mass_binaries = 0
         total_mass_stars = 0


### PR DESCRIPTION
The HDFStore options for pandas include support for compressed datasets. A dataset can be stored using various compression methods, thus reducing storage space on the disk.

(See [reference](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_hdf.html#pandas.DataFrame.to_hdf))

I have added command line options to bin/cosmic-pop which support this feature, without changing the default behavior of COSMIC. A non-zero compression level argument activates the compression.

--------------------------------------------------------------------------------

Thus far I have noticed the most improvement from the blosc:zlib compression library, and with compression level 9. 

I am using the example initialization file `examples/Params.ini` and running an example with the command line for `cosmic-pop --inifile Params.ini --final-kstar1 10 --final-kstar2 10 -n 1 --complib [METHOD] --complevel 9`

Here are the compression libraries I have tried thus and their various sizes (from an ls -lah):

-rw-r--r--  1 xevra xevra  16M Apr  3 02:01 dat_blosc_zlib.h5
-rw-r--r--  1 xevra xevra  19M Apr  2 22:53 dat_bzip2.h5
-rw-r--r--  1 xevra xevra  21M Apr  2 19:34 dat_lzo.h5
-rw-r--r--  1 xevra xevra  38M Apr  1 14:54 dat_old.h5
-rw-r--r--  1 xevra xevra  18M Apr  2 16:16 dat_zlib.h5

You can see that using the blosc:zlib compression library, with a compression level of 9, the example show takes less than half the disk space of the default setting (uncompressed).


