### PR TITLE
Adding feature to extract commit hash

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ py3 = import('python').find_installation()
 numpy_include_dir = run_command(py3, ['-c', 'import numpy; print(numpy.get_include())'], check: true).stdout().strip()
 f2py_include_dir = run_command(py3, ['-c', 'import numpy.f2py; print(numpy.f2py.get_include())'], check: true).stdout().strip()
 inc_np = include_directories(numpy_include_dir, f2py_include_dir)
-
+get_hash = run_command('python', './src/cosmic/get_commit_hash.py', check: true).stdout().strip()
 f2py_source = custom_target(
     'evolvebin-target',
     input : ['src/cosmic/src/evolv2.f', 'src/cosmic/src/comprad.f'],

--- a/src/cosmic/__init__.py
+++ b/src/cosmic/__init__.py
@@ -21,8 +21,10 @@
 """
 
 from ._version import __version__
+from ._commit_hash import COMMIT_HASH
 
 __version__ = __version__
+__commithash__ = COMMIT_HASH
 __author__ = "Katie Breivik <katie.breivik@gmail.com>"
 __credits__ = [
     "Scott Coughlin <scott.coughlin@ligo.org>",

--- a/src/cosmic/get_commit_hash.py
+++ b/src/cosmic/get_commit_hash.py
@@ -1,0 +1,15 @@
+import subprocess
+
+def get_commit_hash():
+    # Run git command to get the latest commit hash
+    result = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    commit_hash = result.stdout.decode('utf-8').strip()
+    return commit_hash
+
+def write_commit_hash_to_file(commit_hash):
+    with open('./src/cosmic/_commit_hash.py', 'w') as f:
+        f.write(f'COMMIT_HASH = "{commit_hash}"\n')
+
+if __name__ == "__main__":
+    commit_hash = get_commit_hash()
+    write_commit_hash_to_file(commit_hash)


### PR DESCRIPTION
With this addition, when cosmic is installed, the file `_commit_hash.py` is created in `src/cosmic`. 

If the user imports cosmic and types `commit.__commithash__`, this will return the commit hash from this version of COSMIC. 