### PR TITLE
build wheels and publish fix

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -32,10 +32,11 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: link gfortran
+    - name: link gfortran and hdf5
       if: runner.os == 'macOS'
       run: |
         sudo ln -s /opt/homebrew/bin/gfortran-12 /usr/local/bin/gfortran
+        brew reinstall hdf5
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel
+        python -m pip install cibuildwheel setuptools
 
     - name: Build source distribution (sdist)
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: link gfortran
       run: |
-        sudo ln -s /opt/homebrew/bin/gfortran-11 /usr/local/bin/gfortran
+        sudo ln -s /opt/homebrew/bin/gfortran-12 /usr/local/bin/gfortran
         ls /opt/homebrew/bin/
         
     - name: Install numpy

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -12,7 +12,6 @@ env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_BEFORE_BUILD: pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
   CIBW_BUILD_VERBOSITY: "1"
-  CIBW_TEST_COMMAND: python src/cosmic/tests/test_evolve.py 
 
 jobs:
   build-wheels-and-dist:

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -32,11 +32,10 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install gfortran
-      if: runner.os == 'macOS'
+    - name: link gfortran
       run: |
         sudo ln -s /opt/homebrew/bin/gfortran-11 /usr/local/bin/gfortran
-        ls /usr/local/bin/gfortran
+        gfortran --version
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.9, "3.10"]
 
     steps:
@@ -35,7 +35,7 @@ jobs:
     - name: Install gfortran
       if: runner.os == 'macOS'
       run: |
-        sudo ln -s /opt/homebrew/bin/gfortran-14 /usr/local/bin/gfortran
+        sudo ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel setuptools
+        python -m pip install cibuildwheel setuptools wheel numpy
 
     - name: Build source distribution (sdist)
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -36,6 +36,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         sudo ln -s /opt/homebrew/bin/gfortran-11 /usr/local/bin/gfortran
+        ls /usr/local/bin/gfortran
         
     - name: Install numpy
       run: |
@@ -44,7 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel setuptools wheel build
+        python -m pip install cibuildwheel setuptools wheel build meson-python ninja meson
 
     - name: Build source distribution (sdist)
       run: |
@@ -52,7 +53,6 @@ jobs:
 
     - name: Build wheels using cibuildwheel
       run: |
-        python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir dist
         
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-11, macos-12, macos-13]
         python-version: [3.9, "3.10"]
 
     steps:
@@ -35,7 +35,7 @@ jobs:
     - name: Install gfortran
       if: runner.os == 'macOS'
       run: |
-        sudo ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
+        sudo ln -s /opt/homebrew/bin/gfortran-11 /usr/local/bin/gfortran
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: [3.9, "3.10"]
 
     steps:
@@ -35,7 +35,7 @@ jobs:
     - name: Install gfortran
       if: runner.os == 'macOS'
       run: |
-        sudo ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
+        sudo ln -s /opt/homebrew/bin/gfortran-14 /usr/local/bin/gfortran
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel setuptools wheel build meson-python ninja meson
+        python -m pip install cibuildwheel==2.17.0 setuptools wheel build meson-python ninja meson
 
     - name: Build source distribution (sdist)
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -84,7 +84,7 @@ jobs:
           name: artifact
           path: dist
 
-    #- name: Publish distribution 📦 to PyPI
-    #  uses: pypa/gh-action-pypi-publish@release/v1
-    #  with:
-    #    password: ${{ secrets.pypi_password }}
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install gfortran
       if: runner.os == 'macOS'
       run: |
-        sudo ln -s /opt/homebrew/bin/gfortran-14 /usr/local/bin/gfortran
+        sudo ln -s /opt/homebrew/bin/gfortran-13 /usr/local/bin/gfortran
         
     - name: Install numpy
       run: |
@@ -85,7 +85,7 @@ jobs:
           name: artifact
           path: dist
 
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.pypi_password }}
+    #- name: Publish distribution 📦 to PyPI
+    #  uses: pypa/gh-action-pypi-publish@release/v1
+    #  with:
+    #    password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel setuptools wheel numpy
+        python -m pip install cibuildwheel setuptools wheel build
 
     - name: Build source distribution (sdist)
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, macos-12, macos-13]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.9, "3.10"]
 
     steps:
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cibuildwheel setuptools wheel twine numpy build meson ninja
+        python -m pip install cibuildwheel
 
     - name: Build source distribution (sdist)
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -35,7 +35,7 @@ jobs:
     - name: link gfortran
       run: |
         sudo ln -s /opt/homebrew/bin/gfortran-11 /usr/local/bin/gfortran
-        gfortran --version
+        ls /opt/homebrew/bin/
         
     - name: Install numpy
       run: |

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -33,9 +33,9 @@ jobs:
         python-version: "3.10"
 
     - name: link gfortran
+      if: runner.os == 'macOS'
       run: |
         sudo ln -s /opt/homebrew/bin/gfortran-12 /usr/local/bin/gfortran
-        ls /opt/homebrew/bin/
         
     - name: Install numpy
       run: |


### PR DESCRIPTION
This patch fixes the buid_wheels_and_publish action which was failing due to cibuildwheel's latest macOS requirement. For now we are pinning to an older version to get the wheels up on pip