### PR TITLE
Allow user customisation of columns in `bpp` and `bcm` tables

### DIFF
--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -360,8 +360,9 @@ class Evolve(object):
         col_inds_bpp[:len(bpp_columns)] = [ALL_COLUMNS.index(col) + 1 for col in bpp_columns]
 
         # save bpp column information in the initial conditions
-        initial_conditions[0]["n_col_bpp"] = len(bpp_columns)
-        initial_conditions[0]["col_inds_bpp"] = col_inds_bpp
+        for i in range(len(initial_conditions)):
+            initial_conditions[i]["n_col_bpp"] = len(bpp_columns)
+            initial_conditions[i]["col_inds_bpp"] = col_inds_bpp
 
         # check if a pool was passed
         if pool is None:

--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -45,23 +45,32 @@ __credits__ = ['Katelyn Breivik <katie.breivik@gmail.com>',
 __all__ = ['Evolve']
 
 
-BPP_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2',
-               'sep', 'porb', 'ecc', 'RRLO_1', 'RRLO_2', 'evol_type',
-               'aj_1', 'aj_2', 'tms_1', 'tms_2',
-               'massc_1', 'massc_2', 'rad_1', 'rad_2',
-               'mass0_1', 'mass0_2', 'lum_1', 'lum_2', 'teff_1', 'teff_2',
-               'radc_1', 'radc_2', 'menv_1', 'menv_2', 'renv_1', 'renv_2',
-               'omega_spin_1', 'omega_spin_2', 'B_1', 'B_2', 'bacc_1', 'bacc_2',
-               'tacc_1', 'tacc_2', 'epoch_1', 'epoch_2',
-               'bhspin_1', 'bhspin_2', 'bin_num']
+# BPP_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2',
+#                'sep', 'porb', 'ecc', 'RRLO_1', 'RRLO_2', 'evol_type',
+#                'aj_1', 'aj_2', 'tms_1', 'tms_2',
+#                'massc_1', 'massc_2', 'rad_1', 'rad_2',
+#                'mass0_1', 'mass0_2', 'lum_1', 'lum_2', 'teff_1', 'teff_2',
+#                'radc_1', 'radc_2', 'menv_1', 'menv_2', 'renv_1', 'renv_2',
+#                'omega_spin_1', 'omega_spin_2', 'B_1', 'B_2', 'bacc_1', 'bacc_2',
+#                'tacc_1', 'tacc_2', 'epoch_1', 'epoch_2',
+#                'bhspin_1', 'bhspin_2', 'bin_num']
 
-BCM_COLUMNS = ['tphys', 'kstar_1', 'mass0_1', 'mass_1', 'lum_1', 'rad_1',
-               'teff_1', 'massc_1', 'radc_1', 'menv_1', 'renv_1', 'epoch_1',
-               'omega_spin_1', 'deltam_1', 'RRLO_1', 'kstar_2', 'mass0_2', 'mass_2',
-               'lum_2', 'rad_2', 'teff_2', 'massc_2', 'radc_2', 'menv_2',
-               'renv_2', 'epoch_2', 'omega_spin_2', 'deltam_2', 'RRLO_2',
-               'porb', 'sep', 'ecc', 'B_1', 'B_2',
-               'SN_1', 'SN_2', 'bin_state', 'merger_type', 'bin_num']
+# BCM_COLUMNS = ['tphys', 'kstar_1', 'mass0_1', 'mass_1', 'lum_1', 'rad_1',
+#                'teff_1', 'massc_1', 'radc_1', 'menv_1', 'renv_1', 'epoch_1',
+#                'omega_spin_1', 'deltam_1', 'RRLO_1', 'kstar_2', 'mass0_2', 'mass_2',
+#                'lum_2', 'rad_2', 'teff_2', 'massc_2', 'radc_2', 'menv_2',
+#                'renv_2', 'epoch_2', 'omega_spin_2', 'deltam_2', 'RRLO_2',
+#                'porb', 'sep', 'ecc', 'B_1', 'B_2',
+#                'SN_1', 'SN_2', 'bin_state', 'merger_type', 'bin_num']
+
+ALL_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2', 'sep', 'porb',
+               'ecc', 'RRLO_1', 'RRLO_2', 'evol_type', 'aj_1', 'aj_2', 'tms_1',
+               'tms_2', 'massc_1', 'massc_2', 'rad_1', 'rad_2', 'mass0_1',
+               'mass0_2', 'lum_1', 'lum_2', 'teff_1', 'teff_2', 'radc_1',
+               'radc_2', 'menv_1', 'menv_2', 'renv_1', 'renv_2', 'omega_spin_1',
+               'omega_spin_2', 'B_1', 'B_2', 'bacc_1', 'bacc_2', 'tacc_1',
+               'tacc_2', 'epoch_1', 'epoch_2', 'bhspin_1', 'bhspin_2', 'bin_num',
+               'deltam_1', 'deltam_2', 'SN_1', 'SN_2', 'bin_state', 'merger_type']
 
 KICK_COLUMNS = ['star', 'disrupted', 'natal_kick', 'phi', 'theta', 'mean_anomaly',
                 'delta_vsysx_1', 'delta_vsysy_1', 'delta_vsysz_1', 'vsys_1_total',

--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -41,8 +41,22 @@ except RuntimeError:
 __author__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
 __credits__ = ['Katelyn Breivik <katie.breivik@gmail.com>',
                'Michael Zevin <zevin@northwestern.edu>',
-               'digman.12@osu.edu']
+               'digman.12@osu.edu',
+               'Tom Wagg <tomjwagg@gmail.com>']
 __all__ = ['Evolve']
+
+
+
+ALL_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2', 'sep', 'porb',
+               'ecc', 'RRLO_1', 'RRLO_2', 'evol_type', 'aj_1', 'aj_2', 'tms_1',
+               'tms_2', 'massc_1', 'massc_2', 'rad_1', 'rad_2', 'mass0_1',
+               'mass0_2', 'lum_1', 'lum_2', 'teff_1', 'teff_2', 'radc_1',
+               'radc_2', 'menv_1', 'menv_2', 'renv_1', 'renv_2', 'omega_spin_1',
+               'omega_spin_2', 'B_1', 'B_2', 'bacc_1', 'bacc_2', 'tacc_1',
+               'tacc_2', 'epoch_1', 'epoch_2', 'bhspin_1', 'bhspin_2',
+               'deltam_1', 'deltam_2', 'SN_1', 'SN_2', 'bin_state', 'merger_type']
+
+INTEGER_COLUMNS = ["bin_state", "bin_num", "kstar_1", "kstar_2", "SN_1", "SN_2", "evol_type"]
 
 
 BPP_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2',
@@ -62,15 +76,6 @@ BCM_COLUMNS = ['tphys', 'kstar_1', 'mass0_1', 'mass_1', 'lum_1', 'rad_1',
                'renv_2', 'epoch_2', 'omega_spin_2', 'deltam_2', 'RRLO_2',
                'porb', 'sep', 'ecc', 'B_1', 'B_2',
                'SN_1', 'SN_2', 'bin_state', 'merger_type']
-
-ALL_COLUMNS = ['tphys', 'mass_1', 'mass_2', 'kstar_1', 'kstar_2', 'sep', 'porb',
-               'ecc', 'RRLO_1', 'RRLO_2', 'evol_type', 'aj_1', 'aj_2', 'tms_1',
-               'tms_2', 'massc_1', 'massc_2', 'rad_1', 'rad_2', 'mass0_1',
-               'mass0_2', 'lum_1', 'lum_2', 'teff_1', 'teff_2', 'radc_1',
-               'radc_2', 'menv_1', 'menv_2', 'renv_1', 'renv_2', 'omega_spin_1',
-               'omega_spin_2', 'B_1', 'B_2', 'bacc_1', 'bacc_2', 'tacc_1',
-               'tacc_2', 'epoch_1', 'epoch_2', 'bhspin_1', 'bhspin_2',
-               'deltam_1', 'deltam_2', 'SN_1', 'SN_2', 'bin_state', 'merger_type']
 
 KICK_COLUMNS = ['star', 'disrupted', 'natal_kick', 'phi', 'theta', 'mean_anomaly',
                 'delta_vsysx_1', 'delta_vsysy_1', 'delta_vsysz_1', 'vsys_1_total',
@@ -364,6 +369,13 @@ class Evolve(object):
             initial_conditions[i]["n_col_bpp"] = len(bpp_columns)
             initial_conditions[i]["col_inds_bpp"] = col_inds_bpp
 
+        # same for bcm
+        col_inds_bcm = np.zeros(len(ALL_COLUMNS), dtype=int)
+        col_inds_bcm[:len(bcm_columns)] = [ALL_COLUMNS.index(col) + 1 for col in bcm_columns]
+        for i in range(len(initial_conditions)):
+            initial_conditions[i]["n_col_bcm"] = len(bcm_columns)
+            initial_conditions[i]["col_inds_bcm"] = col_inds_bcm
+
         # check if a pool was passed
         if pool is None:
             with MultiPool(processes=nproc) as pool:
@@ -419,10 +431,18 @@ class Evolve(object):
                            columns=bcm_columns + ["bin_num"],
                            index=bcm_arrays[:, -1].astype(int))
 
-        bcm.merger_type = bcm.merger_type.astype(int).astype(str).apply(lambda x: x.zfill(4))
-        bcm.bin_state = bcm.bin_state.astype(int)
-        bpp.bin_num = bpp.bin_num.astype(int)
-        bcm.bin_num = bcm.bin_num.astype(int)
+        # convert a subset of columns to integers
+        for col in INTEGER_COLUMNS:
+            if col in bpp.columns:
+                bpp[col] = bpp[col].astype(int)
+            if col in bcm.columns:
+                bcm[col] = bcm[col].astype(int)
+
+        # convert merger type to a padded string
+        if 'merger_type' in bpp.columns:
+            bpp.merger_type = bpp.merger_type.astype(int).astype(str).apply(lambda x: x.zfill(4))
+        if 'merger_type' in bcm.columns:
+            bcm.merger_type = bcm.merger_type.astype(int).astype(str).apply(lambda x: x.zfill(4))
 
         return bpp, bcm, initialbinarytable, kick_info
 
@@ -497,6 +517,8 @@ def _evolve_single_system(f):
 
         _evolvebin.col.n_col_bpp = f["n_col_bpp"]
         _evolvebin.col.col_inds_bpp = f["col_inds_bpp"]
+        _evolvebin.col.n_col_bcm = f["n_col_bcm"]
+        _evolvebin.col.col_inds_bcm = f["col_inds_bcm"]
 
         [bpp_index, bcm_index, kick_info] = _evolvebin.evolv2([f["kstar_1"], f["kstar_2"]],
                                                               [f["mass_1"], f["mass_2"]],
@@ -520,10 +542,10 @@ def _evolve_single_system(f):
                                                               np.zeros(20),
                                                               np.zeros(20),
                                                               f["kick_info"])
-        bcm = _evolvebin.binary.bcm[:bcm_index].copy()
         bpp = _evolvebin.binary.bpp[:bpp_index, :f["n_col_bpp"]].copy()
         _evolvebin.binary.bpp[:bpp_index, :f["n_col_bpp"]] = np.zeros(bpp.shape)
-        _evolvebin.binary.bcm[:bcm_index] = np.zeros(bcm.shape)
+        bcm = _evolvebin.binary.bcm[:bcm_index, :f["n_col_bcm"]].copy()
+        _evolvebin.binary.bcm[:bcm_index, :f["n_col_bcm"]] = np.zeros(bcm.shape)
 
         bpp = np.hstack((bpp, np.ones((bpp.shape[0], 1))*f["bin_num"]))
         bcm = np.hstack((bcm, np.ones((bcm.shape[0], 1))*f["bin_num"]))

--- a/src/cosmic/src/bpp_array.f
+++ b/src/cosmic/src/bpp_array.f
@@ -8,14 +8,18 @@
      &                      teff1,teff2,radc1,radc2,menv1,
      &                      menv2,renv1,renv2,ospin1,ospin2,
      &                      b_0_1,b_0_2,bacc1,bacc2,tacc1,tacc2,
-     &                      epoch1,epoch2,bhspin1,bhspin2)
+     &                      epoch1,epoch2,bhspin1,bhspin2,
+     &                      deltam_1,deltam_2,SN_1,SN_2,
+     &                      bin_state,merger_type)
         IMPLICIT NONE
         INCLUDE 'const_bse.h'
+
+        ! deltam1_bcm,deltam2_bcm,formation(1),formation(2),binstate,mergertype
 *
 * Write results to bpp array.
 *
-*     Author : Scott Coughlin
-*     Date :   12th March 2019
+*     Author : Scott Coughlin, Tom Wagg
+*     Date :   12th March 2019, September 2024
 *
         REAL*8 mass1,mass2
         REAL*8 evolve_type,sep,tb,ecc,tphys,rrl1,rrl2
@@ -24,64 +28,79 @@
         REAL*8 menv1,menv2,renv1,renv2,ospin1,ospin2
         REAL*8 b_0_1,b_0_2,bacc1,bacc2,tacc1,tacc2,epoch1,epoch2
         REAL*8 bhspin1,bhspin2,teff1,teff2
+        REAL*8 deltam_1,deltam_2
+        INTEGER SN_1,SN_2,bin_state,merger_type
         REAL*8 tb_write,sep_cubed
-        INTEGER jp
+        INTEGER jp, col_ind
         INTEGER kstar1,kstar2
         REAL*8 yeardy,aursun,rsunau
+        REAL*8 all_cols(49)
         PARAMETER(yeardy=365.24d0,aursun=214.95d0)
 
-        rsunau = 1/aursun
-        jp = MIN(900,jp + 1)
-        bpp(jp,1) = tphys
-        bpp(jp,2) = mass1
-        bpp(jp,3) = mass2
-        bpp(jp,4) = float(kstar1)
-        bpp(jp,5) = float(kstar2)
-        bpp(jp,6) = sep
+        all_cols(1) = tphys
+        all_cols(2) = mass1
+        all_cols(3) = mass2
+        all_cols(4) = float(kstar1)
+        all_cols(5) = float(kstar2)
+        all_cols(6) = sep
         if(tb.le.0.d0)then
 * system was disrupted and tb=-1 and should stay that way
-            bpp(jp,7) = tb
+            all_cols(7) = tb
         else
             sep_cubed = (sep*rsunau)*(sep*rsunau)*(sep*rsunau)
             tb_write = sqrt(sep_cubed/(mass1+mass2))
-            bpp(jp,7) = tb_write*yeardy
+            all_cols(7) = tb_write*yeardy
         endif
-        bpp(jp,8) = ecc
-        bpp(jp,9) = rrl1
-        bpp(jp,10) = rrl2
-        bpp(jp,11) = evolve_type
-        bpp(jp,12) = aj1
-        bpp(jp,13) = aj2
-        bpp(jp,14) = tms1
-        bpp(jp,15) = tms2
-        bpp(jp,16) = massc1
-        bpp(jp,17) = massc2
-        bpp(jp,18) = rad1
-        bpp(jp,19) = rad2
-        bpp(jp,20) = mass0_1
-        bpp(jp,21) = mass0_2
-        bpp(jp,22) = lumin1
-        bpp(jp,23) = lumin2
-        bpp(jp,24) = teff1
-        bpp(jp,25) = teff2
-        bpp(jp,26) = radc1
-        bpp(jp,27) = radc2
-        bpp(jp,28) = menv1
-        bpp(jp,29) = menv2
-        bpp(jp,30) = renv1
-        bpp(jp,31) = renv2
-        bpp(jp,32) = ospin1
-        bpp(jp,33) = ospin2
-        bpp(jp,34) = b_0_1
-        bpp(jp,35) = b_0_2
-        bpp(jp,36) = bacc1
-        bpp(jp,37) = bacc2
-        bpp(jp,38) = tacc1
-        bpp(jp,39) = tacc2
-        bpp(jp,40) = epoch1
-        bpp(jp,41) = epoch2
-        bpp(jp,42) = bhspin1
-        bpp(jp,43) = bhspin2
+        all_cols(8) = ecc
+        all_cols(9) = rrl1
+        all_cols(10) = rrl2
+        all_cols(11) = evolve_type
+        all_cols(12) = aj1
+        all_cols(13) = aj2
+        all_cols(14) = tms1
+        all_cols(15) = tms2
+        all_cols(16) = massc1
+        all_cols(17) = massc2
+        all_cols(18) = rad1
+        all_cols(19) = rad2
+        all_cols(20) = mass0_1
+        all_cols(21) = mass0_2
+        all_cols(22) = lumin1
+        all_cols(23) = lumin2
+        all_cols(24) = teff1
+        all_cols(25) = teff2
+        all_cols(26) = radc1
+        all_cols(27) = radc2
+        all_cols(28) = menv1
+        all_cols(29) = menv2
+        all_cols(30) = renv1
+        all_cols(31) = renv2
+        all_cols(32) = ospin1
+        all_cols(33) = ospin2
+        all_cols(34) = b_0_1
+        all_cols(35) = b_0_2
+        all_cols(36) = bacc1
+        all_cols(37) = bacc2
+        all_cols(38) = tacc1
+        all_cols(39) = tacc2
+        all_cols(40) = epoch1
+        all_cols(41) = epoch2
+        all_cols(42) = bhspin1
+        all_cols(43) = bhspin2
+        all_cols(44) = deltam_1
+        all_cols(45) = deltam_2
+        all_cols(46) = float(SN_1)
+        all_cols(47) = float(SN_2)
+        all_cols(48) = bin_state
+        all_cols(49) = merger_type
+
+
+        rsunau = 1/aursun
+        jp = MIN(900,jp + 1)
+
+        do 117, col_ind = 1, n_col_bpp
+            bpp(jp,col_ind) = all_cols(col_inds_bpp(col_ind))
+117     continue
         END
 
 ***

--- a/src/cosmic/src/bpp_array.f
+++ b/src/cosmic/src/bpp_array.f
@@ -47,6 +47,7 @@
 * system was disrupted and tb=-1 and should stay that way
             all_cols(7) = tb
         else
+            rsunau = 1/aursun
             sep_cubed = (sep*rsunau)*(sep*rsunau)*(sep*rsunau)
             tb_write = sqrt(sep_cubed/(mass1+mass2))
             all_cols(7) = tb_write*yeardy
@@ -93,8 +94,6 @@
         all_cols(47) = float(SN_2)
         all_cols(48) = bin_state
         all_cols(49) = merger_type
-
-        rsunau = 1/aursun
 
 * check which table we are writing to and write the appropriate columns
         if (tabname .eq. 'bpp') then

--- a/src/cosmic/src/bpp_array.f
+++ b/src/cosmic/src/bpp_array.f
@@ -1,5 +1,5 @@
 ***
-        SUBROUTINE WRITEBPP(jp,tphys,evolve_type,
+        SUBROUTINE WRITETAB(jp,tphys,evolve_type,
      &                      mass1,mass2,kstar1,kstar2,sep,
      &                      tb,ecc,rrl1,rrl2,
      &                      aj1,aj2,tms1,tms2,
@@ -10,13 +10,12 @@
      &                      b_0_1,b_0_2,bacc1,bacc2,tacc1,tacc2,
      &                      epoch1,epoch2,bhspin1,bhspin2,
      &                      deltam_1,deltam_2,SN_1,SN_2,
-     &                      bin_state,merger_type)
+     &                      bin_state,merger_type,tabname)
         IMPLICIT NONE
         INCLUDE 'const_bse.h'
 
-        ! deltam1_bcm,deltam2_bcm,formation(1),formation(2),binstate,mergertype
 *
-* Write results to bpp array.
+* Write results to bpp or bcm array.
 *
 *     Author : Scott Coughlin, Tom Wagg
 *     Date :   12th March 2019, September 2024
@@ -35,6 +34,7 @@
         INTEGER kstar1,kstar2
         REAL*8 yeardy,aursun,rsunau
         REAL*8 all_cols(49)
+        CHARACTER*3 tabname
         PARAMETER(yeardy=365.24d0,aursun=214.95d0)
 
         all_cols(1) = tphys
@@ -94,90 +94,18 @@
         all_cols(48) = bin_state
         all_cols(49) = merger_type
 
-
-        rsunau = 1/aursun
-        jp = MIN(900,jp + 1)
-
-        do 117, col_ind = 1, n_col_bpp
-            bpp(jp,col_ind) = all_cols(col_inds_bpp(col_ind))
-117     continue
-        END
-
-***
-        SUBROUTINE WRITEBCM(ip,tphys,kstar_1,mass0_1,mass_1,
-     &                      lumin_1,rad_1,teff_1,massc_1,
-     &                      radc_1,menv_1,renv_1,epoch_1,
-     &                      ospin_1,deltam_1,RRLO_1,kstar_2,mass0_2,
-     &                      mass_2,lumin_2,rad_2,teff_2,massc_2,radc_2,
-     &                      menv_2,renv_2,epoch_2,ospin_2,deltam_2,
-     &                      RRLO_2,porb,sep,ecc,B_0_1,B_0_2,
-     &                      SN_1,SN_2,bin_state,merger_type)
-        IMPLICIT NONE
-        INCLUDE 'const_bse.h'
-*
-* Write results to bcm array.
-*
-*     Author : Scott Coughlin
-*     Date :   12th March 2019
-*
-        REAL*8 tphys,mass0_1,mass_1,lumin_1,rad_1,teff_1
-        REAL*8 massc_1,radc_1,menv_1,renv_1,epoch_1
-        REAL*8 ospin_1,deltam_1,RRLO_1,porb_write,sep_cubed
-        REAL*8 mass0_2,mass_2,lumin_2,rad_2,teff_2,massc_2
-        REAL*8 radc_2,menv_2,renv_2,epoch_2,ospin_2,deltam_2
-        REAL*8 RRLO_2,porb,sep,ecc,B_0_1,B_0_2
-        INTEGER kstar_1,kstar_2,SN_1,SN_2,bin_state,merger_type
-        INTEGER ip
-        REAL*8 yeardy,aursun,rsunau
-        PARAMETER(yeardy=365.24d0,aursun=214.95d0)
-
         rsunau = 1/aursun
 
-        ip = ip + 1
-        bcm(ip,1) = tphys
-        bcm(ip,2) = float(kstar_1)
-        bcm(ip,3) = mass0_1
-        bcm(ip,4) = mass_1
-        bcm(ip,5) = lumin_1
-        bcm(ip,6) = rad_1
-        bcm(ip,7) = teff_1
-        bcm(ip,8) = massc_1
-        bcm(ip,9) = radc_1
-        bcm(ip,10) = menv_1
-        bcm(ip,11) = renv_1
-        bcm(ip,12) = epoch_1
-        bcm(ip,13) = ospin_1
-        bcm(ip,14) = deltam_1
-        bcm(ip,15) = RRLO_1
-        bcm(ip,16) = float(kstar_2)
-        bcm(ip,17) = mass0_2
-        bcm(ip,18) = mass_2
-        bcm(ip,19) = lumin_2
-        bcm(ip,20) = rad_2
-        bcm(ip,21) = teff_2
-        bcm(ip,22) = massc_2
-        bcm(ip,23) = radc_2
-        bcm(ip,24) = menv_2
-        bcm(ip,25) = renv_2
-        bcm(ip,26) = epoch_2
-        bcm(ip,27) = ospin_2
-        bcm(ip,28) = deltam_2
-        bcm(ip,29) = RRLO_2
-        if(porb.le.0.d0)then
-* system was disrupted and porb=-1 and should stay that way
-            bcm(ip,30) = porb
-        else
-            sep_cubed = (sep*rsunau)*(sep*rsunau)*(sep*rsunau)
-            porb_write = sqrt(sep_cubed/(mass_1+mass_2))
-            bcm(ip,30) = porb_write*yeardy
-        endif
-        bcm(ip,31) = sep
-        bcm(ip,32) = ecc
-        bcm(ip,33) = B_0_1
-        bcm(ip,34) = B_0_2
-        bcm(ip,35) = float(SN_1)
-        bcm(ip,36) = float(SN_2)
-        bcm(ip,37) = bin_state
-        bcm(ip,38) = merger_type
-
+* check which table we are writing to and write the appropriate columns
+        if (tabname .eq. 'bpp') then
+            jp = MIN(900,jp + 1)        ! Why is the 900 limit here??
+            do 117, col_ind = 1, n_col_bpp
+                bpp(jp,col_ind) = all_cols(col_inds_bpp(col_ind))
+117         continue
+        else if (tabname .eq. 'bcm') then
+            jp = jp + 1
+            do 118, col_ind = 1, n_col_bcm
+                bcm(jp,col_ind) = all_cols(col_inds_bcm(col_ind))
+118         continue
+        end if
         END

--- a/src/cosmic/src/comenv.f
+++ b/src/cosmic/src/comenv.f
@@ -6,7 +6,7 @@
      &                  bhspin1,bhspin2,binstate,mergertype,
      &                  jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &                  lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp,
-     &                  bkick)
+     &                  bkick,deltam_1,deltam_2)
       IMPLICIT NONE
       INCLUDE 'const_bse.h'
 *
@@ -39,6 +39,7 @@
       REAL*8 kick_info(2,17),fallback,M1i,M2i
       REAL*8 bkick(20)
       REAL*8 bhspin1,bhspin2
+      REAL*8 deltam_1,deltam_2
       common /fall/fallback
       INTEGER formation1,formation2
       REAL*8 sigmahold
@@ -298,7 +299,7 @@
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0)) 
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -308,13 +309,15 @@
      &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
      &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
      &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1)
+     &                      epoch(1),bhspin2,bhspin1,
+     &                      deltam_2,deltam_1,formation2,formation1,
+     &                      binstate,mergertype,'bpp')
                    else
                        teff1 = 1000.d0*((1130.d0*lumin(1)/
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -324,7 +327,9 @@
      &                      RC1,RC2,menv_bpp(1),menv_bpp(2),renv_bpp(1),
      &                      renv_bpp(2),OSPIN1,OSPIN2,B_0(1),B_0(2),
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin1,bhspin2)
+     &                      epoch(2),bhspin1,bhspin2,
+     &                      deltam_1,deltam_2,formation1,formation2,
+     &                      binstate,mergertype,'bpp')
                    endif
                endif
                CALL kick(KW1,M_postCE,M1,M2,ECC,SEP_postCE,
@@ -599,7 +604,7 @@
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -609,13 +614,15 @@
      &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
      &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
      &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1)
+     &                      epoch(1),bhspin2,bhspin1,
+     &                      deltam_2,deltam_1,formation2,formation1,
+     &                      binstate,mergertype,'bpp')
                    else
                        teff1 = 1000.d0*((1130.d0*lumin(1)/
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -625,7 +632,9 @@
      &                      RC1,RC2,menv_bpp(1),menv_bpp(2),renv_bpp(1),
      &                      renv_bpp(2),OSPIN1,OSPIN2,B_0(1),B_0(2),
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin1,bhspin2)
+     &                      epoch(2),bhspin1,bhspin2,
+     &                      deltam_1,deltam_2,formation1,formation2,
+     &                      binstate,mergertype,'bpp')
                    endif
                endif
 * USSN: if ussn flag is set, have reduced kicks for stripped He stars (SN=8)
@@ -764,7 +773,7 @@
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -774,13 +783,15 @@
      &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
      &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
      &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1)
+     &                      epoch(1),bhspin2,bhspin1,
+     &                      deltam_2,deltam_1,formation2,formation1,
+     &                      binstate,mergertype,'bpp')
                    else
                        teff1 = 1000.d0*((1130.d0*lumin(1)/
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,SEP_postCE,TB,ECC,
      &                       rrl1_bpp,rrl2_bpp,
@@ -790,7 +801,9 @@
      &                      RC1,RC2,menv_bpp(1),menv_bpp(2),renv_bpp(1),
      &                      renv_bpp(2),OSPIN1,OSPIN2,B_0(1),B_0(2),
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin1,bhspin2)
+     &                      epoch(2),bhspin1,bhspin2,
+     &                      deltam_1,deltam_2,formation1,formation2,
+     &                      binstate,mergertype,'bpp')
                    endif
                endif
                CALL kick(KW2,M_postCE,M2,M1,ECC,SEP_postCE,
@@ -992,7 +1005,7 @@
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,-1.d0,TB,0.d0,
      &                       rrl1_bpp,rrl2_bpp,
@@ -1002,13 +1015,15 @@
      &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
      &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
      &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1)
+     &                      epoch(1),bhspin2,bhspin1,
+     &                      deltam_2,deltam_1,formation2,formation1,
+     &                      binstate,mergertype,'bpp')
                    else
                        teff1 = 1000.d0*((1130.d0*lumin(1)/
      &                       (rad1_bpp**2.d0))**(1.d0/4.d0))
                        teff2 = 1000.d0*((1130.d0*lumin(2)/
      &                       (rad2_bpp**2.d0))**(1.d0/4.d0))
-                       CALL writebpp(jp,tphys,evolve_type,
+                       CALL writetab(jp,tphys,evolve_type,
      &                       mass1_bpp,mass2_bpp,kstar1_bpp,
      &                       kstar2_bpp,-1.d0,TB,0.d0,
      &                       rrl1_bpp,rrl2_bpp,
@@ -1018,7 +1033,9 @@
      &                      RC1,RC2,menv_bpp(1),menv_bpp(2),renv_bpp(1),
      &                      renv_bpp(2),OSPIN1,OSPIN2,B_0(1),B_0(2),
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin1,bhspin2)
+     &                      epoch(2),bhspin1,bhspin2,
+     &                      deltam_1,deltam_2,formation1,formation2,
+     &                      binstate,mergertype,'bpp')
                    endif
             endif
             CALL kick(KW,MF,M1,0.d0,0.d0,-1.d0,0.d0,vk,star1,

--- a/src/cosmic/src/const_bse.h
+++ b/src/cosmic/src/const_bse.h
@@ -55,6 +55,9 @@
       COMMON /TSTEPC/ dmmax,drmax
       REAL*8 scm(50000,14),spp(20,3)
       COMMON /SINGLE/ scm,spp
-      REAL*8 bcm(50000,38),bpp(1000,43)
+      REAL*8 bcm(50000,38),bpp(1000,50)
       COMMON /BINARY/ bcm,bpp
+      INTEGER n_col_bpp
+      INTEGER col_inds_bpp(50)
+      COMMON /COL/ n_col_bpp,col_inds_bpp
 *

--- a/src/cosmic/src/const_bse.h
+++ b/src/cosmic/src/const_bse.h
@@ -55,9 +55,9 @@
       COMMON /TSTEPC/ dmmax,drmax
       REAL*8 scm(50000,14),spp(20,3)
       COMMON /SINGLE/ scm,spp
-      REAL*8 bcm(50000,38),bpp(1000,49)
+      REAL*8 bcm(50000,49),bpp(1000,49)
       COMMON /BINARY/ bcm,bpp
-      INTEGER n_col_bpp
-      INTEGER col_inds_bpp(49)
-      COMMON /COL/ n_col_bpp,col_inds_bpp
+      INTEGER n_col_bpp, n_col_bcm
+      INTEGER col_inds_bpp(49), col_inds_bcm(49)
+      COMMON /COL/ n_col_bpp,col_inds_bpp,n_col_bcm,col_inds_bcm
 *

--- a/src/cosmic/src/const_bse.h
+++ b/src/cosmic/src/const_bse.h
@@ -55,9 +55,9 @@
       COMMON /TSTEPC/ dmmax,drmax
       REAL*8 scm(50000,14),spp(20,3)
       COMMON /SINGLE/ scm,spp
-      REAL*8 bcm(50000,38),bpp(1000,50)
+      REAL*8 bcm(50000,38),bpp(1000,49)
       COMMON /BINARY/ bcm,bpp
       INTEGER n_col_bpp
-      INTEGER col_inds_bpp(50)
+      INTEGER col_inds_bpp(49)
       COMMON /COL/ n_col_bpp,col_inds_bpp
 *

--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -1338,7 +1338,9 @@ component.
      &                      menv(1),menv(2),renv(1),renv(2),
      &                      ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin(1),bhspin(2))
+     &                      epoch(2),bhspin(1),bhspin(2),
+     &                      deltam1_bcm,deltam2_bcm,formation(1),
+     &                      formation(2),binstate,mergertype)
                CALL kick(kw,mass(k),mt,0.d0,0.d0,-1.d0,0.d0,vk,k,
      &                  0.d0,fallback,sigmahold,kick_info,disrupt,bkick)
 
@@ -1376,7 +1378,9 @@ component.
      &                       menv(1),menv(2),renv(1),renv(2),
      &                       ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                       bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                       epoch(2),bhspin(1),bhspin(2))
+     &                       epoch(2),bhspin(1),bhspin(2),
+     &                       deltam1_bcm,deltam2_bcm,formation(1),
+     &                       formation(2),binstate,mergertype)
 
                CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
      &              rad(3-k),fallback,sigmahold,kick_info,disrupt,bkick)
@@ -1590,7 +1594,9 @@ component.
      &                  menv(1),menv(2),renv(1),renv(2),
      &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                  epoch(2),bhspin(1),bhspin(2))
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype)
          if(snova)then
             bpp(jp,11) = 2.0
             dtm = 0.d0
@@ -1795,7 +1801,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
       endif
 *
       iter = iter + 1
@@ -1880,7 +1888,9 @@ component.
      &              menv(1),menv(2),renv(1),renv(2),
      &              ospin(1),ospin(2),b01_bcm,b02_bcm,
      &              bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &              epoch(2),bhspin(1),bhspin(2))
+     &              epoch(2),bhspin(1),bhspin(2),
+     &              deltam1_bcm,deltam2_bcm,formation(1),
+     &              formation(2),binstate,mergertype)
 *
       if(check_dtp.eq.1)then
           CALL checkstate(dtp,dtp_original,tsave,tphys,tphysf,
@@ -2370,7 +2380,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
 
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
@@ -2435,7 +2447,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
 *
          epoch(j1) = tphys - aj(j1)
          if(coel)then
@@ -3548,7 +3562,9 @@ component.
      &                    menv(1),menv(2),renv(1),renv(2),
      &                    ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                    epoch(2),bhspin(1),bhspin(2))
+     &                    epoch(2),bhspin(1),bhspin(2),
+     &                    deltam1_bcm,deltam2_bcm,formation(1),
+     &                    formation(2),binstate,mergertype)
             CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
      &              rad(3-k),fallback,sigmahold,kick_info,disrupt,bkick)
             sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
@@ -3727,7 +3743,9 @@ component.
      &                    menv(1),menv(2),renv(1),renv(2),
      &                    ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                    epoch(2),bhspin(1),bhspin(2))
+     &                    epoch(2),bhspin(1),bhspin(2),
+     &                    deltam1_bcm,deltam2_bcm,formation(1),
+     &                    formation(2),binstate,mergertype)
       endif
 
 *
@@ -3773,7 +3791,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
          dtm = 0.d0
          goto 4
       endif
@@ -3822,7 +3842,9 @@ component.
      &              menv(1),menv(2),renv(1),renv(2),
      &              ospin(1),ospin(2),b01_bcm,b02_bcm,
      &              bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &              epoch(2),bhspin(1),bhspin(2))
+     &              epoch(2),bhspin(1),bhspin(2),
+     &              deltam1_bcm,deltam2_bcm,formation(1),
+     &              formation(2),binstate,mergertype)
 *
       kcomp1 = kstar(j1)
       kcomp2 = kstar(j2)
@@ -3867,7 +3889,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
      &               jspin(j2),kstar(j2),zpars,ecc,sep,jorb,coel,j1,j2,
@@ -3948,7 +3972,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
          CALL comenv(mass0(j2),mass(j2),massc(j2),aj(j2),jspin(j2),
      &               kstar(j2),mass0(j1),mass(j1),massc(j1),aj(j1),
      &               jspin(j1),kstar(j1),zpars,ecc,sep,jorb,coel,j2,j1,
@@ -4034,7 +4060,9 @@ component.
      &                  menv(1),menv(2),renv(1),renv(2),
      &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                  epoch(2),bhspin(1),bhspin(2))
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype)
       endif
       epoch(1) = tphys - aj(1)
       epoch(2) = tphys - aj(2)
@@ -4089,7 +4117,9 @@ component.
      &                 menv(1),menv(2),renv(1),renv(2),
      &                 ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                 epoch(2),bhspin(1),bhspin(2))
+     &                 epoch(2),bhspin(1),bhspin(2),
+     &                 deltam1_bcm,deltam2_bcm,formation(1),
+     &                 formation(2),binstate,mergertype)
          dtm = 0.d0
 *
 * Reset orbital parameters as separation may have changed.
@@ -4160,7 +4190,9 @@ component.
      &                        menv(1),menv(2),renv(1),renv(2),
      &                        ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                        epoch(2),bhspin(1),bhspin(2))
+     &                        epoch(2),bhspin(1),bhspin(2),
+     &                        deltam1_bcm,deltam2_bcm,formation(1),
+     &                        formation(2),binstate,mergertype)
             elseif(ecc.gt.1.d0)then
 *
 * Binary dissolved by a supernova or tides.
@@ -4200,7 +4232,9 @@ component.
      &                        menv(1),menv(2),renv(1),renv(2),
      &                        ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                        epoch(2),bhspin(1),bhspin(2))
+     &                        epoch(2),bhspin(1),bhspin(2),
+     &                        deltam1_bcm,deltam2_bcm,formation(1),
+     &                        formation(2),binstate,mergertype)
             else
                 evolve_type = 9.0
                 teff1 = 1000.d0*((1130.d0*lumin(1)/
@@ -4232,7 +4266,9 @@ component.
      &                        menv(1),menv(2),renv(1),renv(2),
      &                        ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                        epoch(2),bhspin(1),bhspin(2))
+     &                        epoch(2),bhspin(1),bhspin(2),
+     &                        deltam1_bcm,deltam2_bcm,formation(1),
+     &                        formation(2),binstate,mergertype)
             endif
          endif
          if(kstar(2).eq.15)then
@@ -4312,7 +4348,9 @@ component.
      &                  menv(1),menv(2),renv(1),renv(2),
      &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                  epoch(2),bhspin(1),bhspin(2))
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype)
           endif
           
 *          if(kstar(1).eq.15.and.bpp(jp,4).lt.15.0)then
@@ -4354,7 +4392,9 @@ component.
      &                      menv(1),menv(2),renv(1),renv(2),
      &                      ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin(1),bhspin(2))
+     &                      epoch(2),bhspin(1),bhspin(2),
+     &                      deltam1_bcm,deltam2_bcm,formation(1),
+     &                      formation(2),binstate,mergertype)
           elseif(kstar(1).eq.15.and.kstar(2).eq.15)then
 *
 * Cases of accretion induced supernova or single star supernova.
@@ -4390,7 +4430,9 @@ component.
      &                      menv(1),menv(2),renv(1),renv(2),
      &                      ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin(1),bhspin(2))
+     &                      epoch(2),bhspin(1),bhspin(2),
+     &                      deltam1_bcm,deltam2_bcm,formation(1),
+     &                      formation(2),binstate,mergertype)
           else
               evolve_type = 10.0
               !added by PA for systems that stop evolving halfway
@@ -4426,7 +4468,9 @@ component.
      &                      menv(1),menv(2),renv(1),renv(2),
      &                      ospin(1),ospin(2),b01_bcm,b02_bcm,
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
-     &                      epoch(2),bhspin(1),bhspin(2))
+     &                      epoch(2),bhspin(1),bhspin(2),
+     &                      deltam1_bcm,deltam2_bcm,formation(1),
+     &                      formation(2),binstate,mergertype)
           endif
       endif
 *

--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -1648,7 +1648,7 @@ component.
             if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
             if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
 
-            CALL writetab(jp,tphys,evolve_type,
+            CALL writetab(ip,tphys,evolve_type,
      &                    mass(1),mass(2),kstar(1),kstar(2),
      &                    sep,tb,ecc,rrl1,rrl2,
      &                    aj(1),aj(2),tms(1),tms(2),
@@ -1939,7 +1939,7 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writetab(jp,tphys,evolve_type,
+          CALL writetab(ip,tphys,evolve_type,
      &                  mass(1),mass(2),kstar(1),kstar(2),
      &                  sep,tb,ecc,rrl1,rrl2,
      &                  aj(1),aj(2),tms(1),tms(2),
@@ -3704,7 +3704,7 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writetab(jp,tphys,evolve_type,
+          CALL writetab(ip,tphys,evolve_type,
      &                  mass(1),mass(2),kstar(1),kstar(2),
      &                  sep,tb,ecc,rrl1,rrl2,
      &                  aj(1),aj(2),tms(1),tms(2),
@@ -4537,7 +4537,7 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writetab(jp,tphys,evolve_type,
+          CALL writetab(ip,tphys,evolve_type,
      &                  mass(1),mass(2),kstar(1),kstar(2),
      &                  sep,tb,ecc,rrl1,rrl2,
      &                  aj(1),aj(2),tms(1),tms(2),

--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -1328,7 +1328,7 @@ component.
                else
                   b02_bcm = B(2)
                endif
-               CALL writebpp(jp,tphys,evolve_type,
+               CALL writetab(jp,tphys,evolve_type,
      &                      mass(1),mass(2),kstar(1),kstar(2),
      &                      sep,tb,ecc,rrl1,rrl2,
      &                      aj(1),aj(2),tms(1),tms(2),
@@ -1340,7 +1340,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2),
      &                      deltam1_bcm,deltam2_bcm,formation(1),
-     &                      formation(2),binstate,mergertype)
+     &                      formation(2),binstate,mergertype,'bpp')
                CALL kick(kw,mass(k),mt,0.d0,0.d0,-1.d0,0.d0,vk,k,
      &                  0.d0,fallback,sigmahold,kick_info,disrupt,bkick)
 
@@ -1368,7 +1368,7 @@ component.
                   b02_bcm = B(2)
                endif
 
-               CALL writebpp(jp,tphys,evolve_type,
+               CALL writetab(jp,tphys,evolve_type,
      &                       mass(1),mass(2),kstar(1),kstar(2),
      &                       sep,tb,ecc,rrl1,rrl2,
      &                       aj(1),aj(2),tms(1),tms(2),
@@ -1380,7 +1380,7 @@ component.
      &                       bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                       epoch(2),bhspin(1),bhspin(2),
      &                       deltam1_bcm,deltam2_bcm,formation(1),
-     &                       formation(2),binstate,mergertype)
+     &                       formation(2),binstate,mergertype,'bpp')
 
                CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
      &              rad(3-k),fallback,sigmahold,kick_info,disrupt,bkick)
@@ -1584,7 +1584,7 @@ component.
              b02_bcm = B(2)
           endif
 
-          CALL writebpp(jp,tphys,evolve_type,
+          CALL writetab(jp,tphys,evolve_type,
      &                  mass(1),mass(2),kstar(1),kstar(2),sep,
      &                  tb,ecc,rrl1,rrl2,
      &                  aj(1),aj(2),tms(1),tms(2),
@@ -1596,7 +1596,7 @@ component.
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                  epoch(2),bhspin(1),bhspin(2),
      &                  deltam1_bcm,deltam2_bcm,formation(1),
-     &                  formation(2),binstate,mergertype)
+     &                  formation(2),binstate,mergertype,'bpp')
          if(snova)then
             bpp(jp,11) = 2.0
             dtm = 0.d0
@@ -1648,14 +1648,19 @@ component.
             if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
             if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
 
-            CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
-     &                    lumin(1),rad(1),teff1,massc(1),
-     &                    radc(1),menv(1),renv(1),epoch(1),
-     &                    ospin(1),deltam1_bcm,rrl1,kstar(2),mass0(2),
-     &                    mass(2),lumin(2),rad(2),teff2,massc(2),
-     &                    radc(2),menv(2),renv(2),epoch(2),ospin(2),
-     &                    deltam2_bcm,rrl2,tb,sep,ecc,b01_bcm,b02_bcm,
-     &                    formation(1),formation(2),binstate,mergertype)
+            CALL writetab(jp,tphys,evolve_type,
+     &                    mass(1),mass(2),kstar(1),kstar(2),
+     &                    sep,tb,ecc,rrl1,rrl2,
+     &                    aj(1),aj(2),tms(1),tms(2),
+     &                    massc(1),massc(2),rad(1),rad(2),
+     &                    mass0(1),mass0(2),lumin(1),lumin(2),
+     &                    teff1,teff2,radc(1),radc(2),
+     &                    menv(1),menv(2),renv(1),renv(2),
+     &                    ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                    epoch(2),bhspin(1),bhspin(2),
+     &                    deltam1_bcm,deltam2_bcm,formation(1),
+     &                    formation(2),binstate,mergertype,'bcm')
             if(isave) tsave = tsave + dtp
             if(output) write(*,*)'bcm1',kstar(1),kstar(2),mass(1),
      & mass(2),rad(1),rad(2),ospin(1),ospin(2),jspin(1)
@@ -1791,7 +1796,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
      &                 aj(1),aj(2),tms(1),tms(2),
@@ -1803,7 +1808,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
       endif
 *
       iter = iter + 1
@@ -1878,7 +1883,7 @@ component.
          b02_bcm = B(2)
       endif
 
-      CALL writebpp(jp,tphys,evolve_type,
+      CALL writetab(jp,tphys,evolve_type,
      &              mass(1),mass(2),kstar(1),kstar(2),sep,
      &              tb,ecc,rrl1,rrl2,
      &              aj(1),aj(2),tms(1),tms(2),
@@ -1890,7 +1895,7 @@ component.
      &              bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &              epoch(2),bhspin(1),bhspin(2),
      &              deltam1_bcm,deltam2_bcm,formation(1),
-     &              formation(2),binstate,mergertype)
+     &              formation(2),binstate,mergertype,'bpp')
 *
       if(check_dtp.eq.1)then
           CALL checkstate(dtp,dtp_original,tsave,tphys,tphysf,
@@ -1934,14 +1939,19 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
-     &                  lumin(1),rad(1),teff1,massc(1),
-     &                  radc(1),menv(1),renv(1),epoch(1),
-     &                  ospin(1),deltam1_bcm,rrl1,kstar(2),mass0(2),
-     &                  mass(2),lumin(2),rad(2),teff2,massc(2),
-     &                  radc(2),menv(2),renv(2),epoch(2),ospin(2),
-     &                  deltam2_bcm,rrl2,tb,sep,ecc,b01_bcm,b02_bcm,
-     &                  formation(1),formation(2),binstate,mergertype)
+          CALL writetab(jp,tphys,evolve_type,
+     &                  mass(1),mass(2),kstar(1),kstar(2),
+     &                  sep,tb,ecc,rrl1,rrl2,
+     &                  aj(1),aj(2),tms(1),tms(2),
+     &                  massc(1),massc(2),rad(1),rad(2),
+     &                  mass0(1),mass0(2),lumin(1),lumin(2),
+     &                  teff1,teff2,radc(1),radc(2),
+     &                  menv(1),menv(2),renv(1),renv(2),
+     &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype,'bcm')
          if(output) write(*,*)'bcm2:',kstar(1),kstar(2),mass(1),
      & mass(2),rad(1),rad(2),ospin(1),ospin(2),jspin(1)
 *     & mass(2),rad(1),rad(2),ospin(1),ospin(2),b01_bcm,b02_bcm,jspin(1)
@@ -2369,7 +2379,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),
      &                 kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
@@ -2382,7 +2392,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
 
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
@@ -2436,7 +2446,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass1_bpp,mass2_bpp,
      &                 kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
@@ -2449,7 +2459,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
 *
          epoch(j1) = tphys - aj(j1)
          if(coel)then
@@ -3552,7 +3562,7 @@ component.
             else
                b02_bcm = B(2)
             endif
-            CALL writebpp(jp,tphys,evolve_type,
+            CALL writetab(jp,tphys,evolve_type,
      &                    mass(1),mass(2),kstar(1),kstar(2),
      &                    sep,tb,ecc,rrl1,rrl2,
      &                    aj(1),aj(2),tms(1),tms(2),
@@ -3564,7 +3574,7 @@ component.
      &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                    epoch(2),bhspin(1),bhspin(2),
      &                    deltam1_bcm,deltam2_bcm,formation(1),
-     &                    formation(2),binstate,mergertype)
+     &                    formation(2),binstate,mergertype,'bpp')
             CALL kick(kw,mass(k),mt,mass(3-k),ecc,sep,jorb,vk,k,
      &              rad(3-k),fallback,sigmahold,kick_info,disrupt,bkick)
             sigma = sigmahold !reset sigma after possible ECSN kick dist. Remove this if u want some kick link to the intial pulsar values...
@@ -3693,14 +3703,19 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
-     &                  lumin(1),rad(1),teff1,massc(1),
-     &                  radc(1),menv(1),renv(1),epoch(1),
-     &                  ospin(1),deltam1_bcm,rrl1,kstar(2),mass0(2),
-     &                  mass(2),lumin(2),rad(2),teff2,massc(2),
-     &                  radc(2),menv(2),renv(2),epoch(2),ospin(2),
-     &                  deltam2_bcm,rrl2,tb,sep,ecc,b01_bcm,b02_bcm,
-     &                  formation(1),formation(2),binstate,mergertype)
+          CALL writetab(jp,tphys,evolve_type,
+     &                  mass(1),mass(2),kstar(1),kstar(2),
+     &                  sep,tb,ecc,rrl1,rrl2,
+     &                  aj(1),aj(2),tms(1),tms(2),
+     &                  massc(1),massc(2),rad(1),rad(2),
+     &                  mass0(1),mass0(2),lumin(1),lumin(2),
+     &                  teff1,teff2,radc(1),radc(2),
+     &                  menv(1),menv(2),renv(1),renv(2),
+     &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype,'bcm')
          if(isave) tsave = tsave + dtp
          if(output) write(*,*)'bcm3:',kstar(1),kstar(2),mass(1),
      & mass(2),rad(1),rad(2),ospin(1),ospin(2),jspin(1)
@@ -3733,7 +3748,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                    mass(1),mass(2),kstar(1),kstar(2),
      &                    sep,tb,ecc,rrl1,rrl2,
      &                    aj(1),aj(2),tms(1),tms(2),
@@ -3745,7 +3760,7 @@ component.
      &                    bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                    epoch(2),bhspin(1),bhspin(2),
      &                    deltam1_bcm,deltam2_bcm,formation(1),
-     &                    formation(2),binstate,mergertype)
+     &                    formation(2),binstate,mergertype,'bpp')
       endif
 
 *
@@ -3781,7 +3796,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
      &                 aj(1),aj(2),tms(1),tms(2),
@@ -3793,7 +3808,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
          dtm = 0.d0
          goto 4
       endif
@@ -3832,7 +3847,7 @@ component.
       else
          b02_bcm = B(2)
       endif
-      CALL writebpp(jp,tphys,evolve_type,
+      CALL writetab(jp,tphys,evolve_type,
      &              mass(1),mass(2),kstar(1),kstar(2),sep,
      &              tb,ecc,rrl1,rrl2,
      &              aj(1),aj(2),tms(1),tms(2),
@@ -3844,7 +3859,7 @@ component.
      &              bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &              epoch(2),bhspin(1),bhspin(2),
      &              deltam1_bcm,deltam2_bcm,formation(1),
-     &              formation(2),binstate,mergertype)
+     &              formation(2),binstate,mergertype,'bpp')
 *
       kcomp1 = kstar(j1)
       kcomp2 = kstar(j2)
@@ -3878,7 +3893,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),
      &                 kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
@@ -3891,7 +3906,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
          CALL comenv(mass0(j1),mass(j1),massc(j1),aj(j1),jspin(j1),
      &               kstar(j1),mass0(j2),mass(j2),massc(j2),aj(j2),
      &               jspin(j2),kstar(j2),zpars,ecc,sep,jorb,coel,j1,j2,
@@ -3961,7 +3976,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),
      &                 kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
@@ -3974,7 +3989,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
          CALL comenv(mass0(j2),mass(j2),massc(j2),aj(j2),jspin(j2),
      &               kstar(j2),mass0(j1),mass(j1),massc(j1),aj(j1),
      &               jspin(j1),kstar(j1),zpars,ecc,sep,jorb,coel,j2,j1,
@@ -4049,7 +4064,7 @@ component.
              b02_bcm = B(2)
           endif
 
-          CALL writebpp(jp,tphys,evolve_type,
+          CALL writetab(jp,tphys,evolve_type,
      &                  mass1_bpp,mass2_bpp,
      &                  kstar(1),kstar(2),sep,
      &                  tb,ecc,rrl1,rrl2,
@@ -4062,7 +4077,7 @@ component.
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                  epoch(2),bhspin(1),bhspin(2),
      &                  deltam1_bcm,deltam2_bcm,formation(1),
-     &                  formation(2),binstate,mergertype)
+     &                  formation(2),binstate,mergertype,'bpp')
       endif
       epoch(1) = tphys - aj(1)
       epoch(2) = tphys - aj(2)
@@ -4107,7 +4122,7 @@ component.
             b02_bcm = B(2)
          endif
 
-         CALL writebpp(jp,tphys,evolve_type,
+         CALL writetab(jp,tphys,evolve_type,
      &                 mass(1),mass(2),kstar(1),kstar(2),sep,
      &                 tb,ecc,rrl1,rrl2,
      &                 aj(1),aj(2),tms(1),tms(2),
@@ -4119,7 +4134,7 @@ component.
      &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                 epoch(2),bhspin(1),bhspin(2),
      &                 deltam1_bcm,deltam2_bcm,formation(1),
-     &                 formation(2),binstate,mergertype)
+     &                 formation(2),binstate,mergertype,'bpp')
          dtm = 0.d0
 *
 * Reset orbital parameters as separation may have changed.
@@ -4179,7 +4194,7 @@ component.
                 else
                    b02_bcm = B(2)
                 endif
-                CALL writebpp(jp,tphys,evolve_type,
+                CALL writetab(jp,tphys,evolve_type,
      &                        mass1_bpp,mass2_bpp,
      &                        kstar(1),kstar(2),0.d0,
      &                        0.d0,-1.d0,0.d0,ngtv,
@@ -4192,7 +4207,7 @@ component.
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                        epoch(2),bhspin(1),bhspin(2),
      &                        deltam1_bcm,deltam2_bcm,formation(1),
-     &                        formation(2),binstate,mergertype)
+     &                        formation(2),binstate,mergertype,'bpp')
             elseif(ecc.gt.1.d0)then
 *
 * Binary dissolved by a supernova or tides.
@@ -4221,7 +4236,7 @@ component.
                 else
                    b02_bcm = B(2)
                 endif
-                CALL writebpp(jp,tphys,evolve_type,
+                CALL writetab(jp,tphys,evolve_type,
      &                        mass1_bpp,mass2_bpp,
      &                        kstar(1),kstar(2),sep,
      &                        tb,ecc,0.d0,ngtv2,
@@ -4234,7 +4249,7 @@ component.
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                        epoch(2),bhspin(1),bhspin(2),
      &                        deltam1_bcm,deltam2_bcm,formation(1),
-     &                        formation(2),binstate,mergertype)
+     &                        formation(2),binstate,mergertype,'bpp')
             else
                 evolve_type = 9.0
                 teff1 = 1000.d0*((1130.d0*lumin(1)/
@@ -4255,7 +4270,7 @@ component.
                 else
                    b02_bcm = B(2)
                 endif
-                CALL writebpp(jp,tphys,evolve_type,
+                CALL writetab(jp,tphys,evolve_type,
      &                        mass1_bpp,mass2_bpp,
      &                        kstar(1),kstar(2),0.d0,
      &                        0.d0,0.d0,0.d0,ngtv,
@@ -4268,7 +4283,7 @@ component.
      &                        bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                        epoch(2),bhspin(1),bhspin(2),
      &                        deltam1_bcm,deltam2_bcm,formation(1),
-     &                        formation(2),binstate,mergertype)
+     &                        formation(2),binstate,mergertype,'bpp')
             endif
          endif
          if(kstar(2).eq.15)then
@@ -4338,7 +4353,7 @@ component.
                  b02_bcm = B(2)
               endif
 
-              CALL writebpp(jp,tphys,evolve_type,
+              CALL writetab(jp,tphys,evolve_type,
      &                  mass(1),mass(2),kstar(1),kstar(2),sep,
      &                  tb,ecc,rrl1,rrl2,
      &                  aj(1),aj(2),tms(1),tms(2),
@@ -4350,7 +4365,7 @@ component.
      &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                  epoch(2),bhspin(1),bhspin(2),
      &                  deltam1_bcm,deltam2_bcm,formation(1),
-     &                  formation(2),binstate,mergertype)
+     &                  formation(2),binstate,mergertype,'bpp')
           endif
           
 *          if(kstar(1).eq.15.and.bpp(jp,4).lt.15.0)then
@@ -4381,7 +4396,7 @@ component.
               else
                  b02_bcm = B(2)
               endif
-              CALL writebpp(jp,tphys,evolve_type,
+              CALL writetab(jp,tphys,evolve_type,
      &                      mass1_bpp,mass2_bpp,
      &                      kstar(1),kstar(2),0.d0,
      &                      0.d0,-1.d0,0.d0,ngtv,
@@ -4394,7 +4409,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2),
      &                      deltam1_bcm,deltam2_bcm,formation(1),
-     &                      formation(2),binstate,mergertype)
+     &                      formation(2),binstate,mergertype,'bpp')
           elseif(kstar(1).eq.15.and.kstar(2).eq.15)then
 *
 * Cases of accretion induced supernova or single star supernova.
@@ -4419,7 +4434,7 @@ component.
               else
                  b02_bcm = B(2)
               endif
-              CALL writebpp(jp,tphys,evolve_type,
+              CALL writetab(jp,tphys,evolve_type,
      &                      mass1_bpp,mass2_bpp,
      &                      kstar(1),kstar(2),0.d0,
      &                      0.d0,0.d0,0.d0,ngtv2,
@@ -4432,7 +4447,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2),
      &                      deltam1_bcm,deltam2_bcm,formation(1),
-     &                      formation(2),binstate,mergertype)
+     &                      formation(2),binstate,mergertype,'bpp')
           else
               evolve_type = 10.0
               !added by PA for systems that stop evolving halfway
@@ -4457,7 +4472,7 @@ component.
               else
                  b02_bcm = B(2)
               endif
-              CALL writebpp(jp,tphys,evolve_type,
+              CALL writetab(jp,tphys,evolve_type,
      &                      mass1_bpp,mass2_bpp,
      &                      kstar(1),kstar(2),sep,
      &                      tb,ecc,rrl1,rrl2,
@@ -4470,7 +4485,7 @@ component.
      &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
      &                      epoch(2),bhspin(1),bhspin(2),
      &                      deltam1_bcm,deltam2_bcm,formation(1),
-     &                      formation(2),binstate,mergertype)
+     &                      formation(2),binstate,mergertype,'bpp')
           endif
       endif
 *
@@ -4519,14 +4534,19 @@ component.
 * Check if PISN occurred, and if so overwrite formation
           if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
           if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
-          CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
-     &                  lumin(1),rad(1),teff1,massc(1),
-     &                  radc(1),menv(1),renv(1),epoch(1),
-     &                  ospin(1),deltam1_bcm,rrl1,kstar(2),mass0(2),
-     &                  mass(2),lumin(2),rad(2),teff2,massc(2),
-     &                  radc(2),menv(2),renv(2),epoch(2),ospin(2),
-     &                  deltam2_bcm,rrl2,tb,sep,ecc,b01_bcm,b02_bcm,
-     &                  formation(1),formation(2),binstate,mergertype)
+          CALL writetab(jp,tphys,evolve_type,
+     &                  mass(1),mass(2),kstar(1),kstar(2),
+     &                  sep,tb,ecc,rrl1,rrl2,
+     &                  aj(1),aj(2),tms(1),tms(2),
+     &                  massc(1),massc(2),rad(1),rad(2),
+     &                  mass0(1),mass0(2),lumin(1),lumin(2),
+     &                  teff1,teff2,radc(1),radc(2),
+     &                  menv(1),menv(2),renv(1),renv(2),
+     &                  ospin(1),ospin(2),b01_bcm,b02_bcm,
+     &                  bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                  epoch(2),bhspin(1),bhspin(2),
+     &                  deltam1_bcm,deltam2_bcm,formation(1),
+     &                  formation(2),binstate,mergertype,'bcm')
          if(output) write(*,*)'bcm4:',kstar(1),kstar(2),mass(1),
      & mass(2),rad(1),rad(2),ospin(1),ospin(2),jspin(1),
      & tphys,tphysf

--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -2400,7 +2400,8 @@ component.
      &               vk,kick_info,formation(j1),formation(j2),sigmahold,
      &               bhspin(j1),bhspin(j2),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
-     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick)
+     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick,
+     &               deltam1_bcm,deltam2_bcm)
          if(binstate.eq.1.d0)then
              sep = 0.d0
              tb = 0.d0
@@ -3913,7 +3914,8 @@ component.
      &               vk,kick_info,formation(j1),formation(j2),sigmahold,
      &               bhspin(j1),bhspin(j2),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
-     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick)
+     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick,
+     &               deltam1_bcm,deltam2_bcm)
          if(output) write(*,*)'coal1:',tphys,kstar(j1),kstar(j2),coel,
      & mass(j1),mass(j2)
          if(j1.eq.2.and.kcomp2.eq.13.and.kstar(j2).eq.15.and.
@@ -3996,7 +3998,8 @@ component.
      &               vk,kick_info,formation(j2),formation(j1),sigmahold,
      &               bhspin(j2),bhspin(j1),binstate,mergertype,
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
-     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick)
+     &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick,
+     &               deltam1_bcm,deltam2_bcm)
          if(output) write(*,*)'coal2:',tphys,kstar(j1),kstar(j2),coel,
      & mass(j1),mass(j2)
          if(j2.eq.2.and.kcomp1.eq.13.and.kstar(j1).eq.15.and.


### PR DESCRIPTION
I've added two arguments to `Evolve.evolve()`, `bpp_columns` and `bcm_columns`. Users can specify a list of columns to include in either table, by default it will use the current setup so no breaking changes with this 😅 I've made the changes directly in the Fortran as well so this will perhaps cut down on RAM usage during the run.

The only change I made that alters the default behaviour is to report `kstar_x` and `evol_type` as integers instead of floats, which I think makes sense?

(Selfishly motivated by TomWagg/cogsworth#86 🙃)

### Implementation details

The way it works is:

- Define a list of all possible columns (in python and in fortran files)
- Convert user input into a number of columns in each table and indices of the variables you want to add
- In `writetab` (new function that combines `writebpp` and `writebcm` in a simpler way), access the specific variables in the order the inds specify

This means I had to define some new variables in `const_bse.h` and also change the calling of `writebpp` and `writebcm` everywhere.

### Demo

Default behaviour
![image](https://github.com/user-attachments/assets/f5c5f042-e29c-4358-b8fa-2c6c7c68a64c)

Specifying certain columns
![image](https://github.com/user-attachments/assets/1333c289-37da-42a6-92dc-de284f58d302)
