### PR TITLE
Fix NaNs coming from supernova kicks

### DIFF
--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -2402,6 +2402,32 @@ component.
      &               jp,tphys,switchedCE,rad,tms,evolve_type,disrupt,
      &               lumin,B_0,bacc,tacc,epoch,menv,renv,bkick,
      &               deltam1_bcm,deltam2_bcm)
+         if(j1.eq.2.and.kcomp2.eq.13.and.kstar(j2).eq.15.and.
+     &      kstar(j1).eq.13)then !PK.
+* In CE the NS got switched around. Do same to formation.
+            formation(j1) = formation(j2)
+         endif
+         if(j1.eq.1.and.kcomp2.eq.13.and.kstar(j2).eq.15.and.
+     &      kstar(j1).eq.13)then !PK.
+* In CE the NS got switched around. Do same to formation.
+            formation(j1) = formation(j2)
+         endif
+         com = .true.
+         if(com.and..not.coel.and..not.disrupt)then
+* if it went through common envelope
+* did not disrupt (from one of the objects going SN)
+* and did not merge in common envelope
+* then system is still in binary
+            binstate = 0
+            mergertype = -1
+         elseif(com.and..not.coel.and.disrupt)then
+* if it went through common envelope
+* and did disrupt (from one of the objects going SN)
+* and did not merge in common envelope
+* then system should be marked as disrupted
+            binstate = 2
+            mergertype = -1
+         endif
          if(binstate.eq.1.d0)then
              sep = 0.d0
              tb = 0.d0

--- a/src/cosmic/src/kick.f
+++ b/src/cosmic/src/kick.f
@@ -626,18 +626,28 @@
 
 * first two special cases for orbital A.M. remaining unchanged in angle
 * since the cross product is not well defined in this case
-         if(thetaE.eq.0.d0.and.ecc_prev.gt.0.d0.and.ecc.gt.0.d0)then
+         if(thetaE.eq.0.d0)then
             xx = ran3(idum1)
-            xx = ran3(idum1)
-            call AngleBetweenVectors(LRL, LRL_prev, psiPlusPhi)
             phiE = twopi * xx
-            psiE = psiPlusPhi - phiE
-         else if(thetaE.eq.pi.and.ecc_prev.gt.0.d0.and.ecc.gt.0.d0)then
             xx = ran3(idum1)
+* we can only calculate the angle if the eccentricity is nonzero
+            if (ecc_prev.gt.0.d0.and.ecc.gt.0.d0)then
+               call AngleBetweenVectors(LRL, LRL_prev, psiPlusPhi)
+               psiE = psiPlusPhi - phiE
+            else
+               psiE = twopi * xx
+            end if            
+         else if(thetaE.eq.pi)then
             xx = ran3(idum1)
-            call AngleBetweenVectors(LRL, LRL_prev, psiPlusPhi)
             phiE = twopi * xx
-            psiE = phiE + psiPlusPhi
+            xx = ran3(idum1)
+* we can only calculate the angle if the eccentricity is nonzero
+            if (ecc_prev.gt.0.d0.and.ecc.gt.0.d0)then
+               call AngleBetweenVectors(LRL, LRL_prev, psiPlusPhi)
+               psiE = phiE + psiPlusPhi
+            else
+               psiE = twopi * xx
+            end if
 * now we can actually use the cross product to get the pivot axis
          else
             call CrossProduct(h_prev, h, orbital_pivot_axis)


### PR DESCRIPTION
This fixes two different bugs that result in NaNs in the `bpp` and `kick_info` tables. Here's details on both:

# NaN in $\psi_{\rm Euler}$

This one's my fault 😅 In cases where **both** the natal kick is 0km/s _and_ the pre-SN eccentricity is 0.0 then one cannot compute the cross product (a) between the orbital angular momentum pre/post-SN or (b) between the pre/post-SN Laplace-Runge-Lenz vector. I've added conditions for this situation and just use a random angle in this case.

**Example system  for reproducing:** `["mass_1", "mass_2", "porb", "ecc", "metallicity"] = [51.824108, 24.551823, 10.904105, 0.071088, 0.001284]`

# NaN in `porb`

Based on guesswork alone, I think this one is coming from someone adding a call to `COMENV()` but not also copying the code below it which is necessary for bookkeeping. This means that if a supernova occurs **during a CE** the `porb` post-SN is set to a NaN because the `binstate` hasn't been updated. I added the same code that's below the other 2 calls to `COMENV()`. @katiebreivik you should check that this should all be here...I _think_ it should but something to look at closely.

**Example system for reproducing:** `["mass_1", "mass_2", "porb", "ecc", "metallicity"] = [46.211960, 15.483146, 6639.574181, 0.589395, 0.00192]]`


Slowly winning our campaign against NaNs 🎉 