### PR TITLE
Avoid NaNs from massless remnant kicks, fix debugging setup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
             "type": "shell",
             "command": "make test",
             "options": {
-                "cwd": "${workspaceFolder}/cosmic/src"
+                "cwd": "${workspaceFolder}/src/cosmic/src"
             },
         }
     ]

--- a/debug/create_binary_in.py
+++ b/debug/create_binary_in.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import argparse
 
 BSE_settings = {'xi': 1.0, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 1, 'alpha1': 1.0,
                 'pts1': 0.001, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 0.5,
@@ -33,7 +34,12 @@ def create_binary_in(mass0, tphysf, tb, kstar, Z, ecc, BSE_settings):
             ['neta', 'bwind', 'hewind', 'alpha1', 'lambdaf', 'windflag', 'rtmsflag'],
             ['ceflag', 'tflag', 'ifflag', 'wdflag', 'bhflag', 'remnantflag', 'mxns', 'idum'],
             ['pts1', 'pts2', 'pts3'],
-            ['sigma', 'beta', 'xi', 'acc2', 'epsnov', 'eddfac', 'gamma']
+            ['sigma', 'beta', 'xi', 'acc2', 'epsnov', 'eddfac', 'gamma', 'kickflag'],
+            ['pisn', 'cekickflag', 'cehestarflag', 'grflag', 'bhms_coll_flag'],
+            ['wd_mass_lim', 'ecsn', 'ecsn_mlow', 'aic', 'ussn', 'sigmadiv', 'bhsigmafrac'],
+            ['don_lim', 'acc_lim', 'bdecayfac', 'bconst', 'ck', 'qcflag', 'eddlimflag'],
+            ['bhspinflag', 'bhspinmag', 'rejuv_fac', 'rejuvflag', 'htpmb', 'ST_cr'],
+            ['ST_tide', 'rembar_massloss', 'zsun']
         ]
 
         for line in lines:
@@ -58,9 +64,22 @@ def convert_initC_row_to_binary_in(initC_file, bin_num):
     BSE_settings['idum'] = r['randomseed'].astype(int)
     for key in BSE_settings:
         if key in r:
-            BSE_settings[key] = r[key]
+            BSE_settings[key] = r[key].astype(type(BSE_settings[key]))
 
     # create binary.in file
     create_binary_in([r['mass_1'], r['mass_2']], r['tphysf'], r['porb'],
-                    [r['kstar_1'].astype(int), r['kstar_2'].astype(int)],
-                    r['metallicity'], r['ecc'], BSE_settings)
+                     [r['kstar_1'].astype(int), r['kstar_2'].astype(int)],
+                     r['metallicity'], r['ecc'], BSE_settings)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert a row from an initC file to a binary.in file')
+    parser.add_argument('-f', '--initC_file', type=str, help='Path to the initC file')
+    parser.add_argument('-b', '--bin_num', type=int, help='The binary number to convert')
+    args = parser.parse_args()
+
+    convert_initC_row_to_binary_in(args.initC_file, args.bin_num)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cosmic/src/Makefile
+++ b/src/cosmic/src/Makefile
@@ -16,7 +16,7 @@ OBJT1 = $(SRC:.f=.o)
 
 test:    $(OBJT1) $(LFLAGS)
 	$(CMPLR) $(FFLAGS) $(OBJT1) -o test
-	mv test ../../debug/test
+	mv test ../../../debug/test
 
 clean:
 	rm -f *.o ../../debug/test

--- a/src/cosmic/src/kick.f
+++ b/src/cosmic/src/kick.f
@@ -320,7 +320,8 @@
 
 * Check if the system is already not a bound binary
       if((sn.eq.2.and.kick_info(1,2).eq.1)
-     &   .or.sep.le.0.or.ecc.lt.0)then
+     &   .or.sep.le.0.or.ecc.lt.0
+     &   .or.sep.ne.sep.or.ecc.ne.ecc)then
 * if so, only apply kick to the current star
          disrupt = .true.
          kick_info(sn,2) = 1

--- a/src/cosmic/src/kick.f
+++ b/src/cosmic/src/kick.f
@@ -251,6 +251,15 @@
              vk2 = vk*vk
           endif
 
+* If a massless remnant is produced then artificially set the kick to
+* a large value that will cause a disruption. This avoids infinite kicks
+* for prescriptions that scale with the mass of the remnant.
+* See Issue #687
+          if(m1n.le.0.d0)then
+             vk = 10000.d0
+             vk2 = vk * vk
+          endif
+
       endif
       sigma = sigmah
 

--- a/src/cosmic/src/test_bse.f
+++ b/src/cosmic/src/test_bse.f
@@ -100,7 +100,13 @@
       READ(22,*)neta,bwind,hewind,alpha1,lambdaf,windflag,rtmsflag
       READ(22,*)ceflag,tflag,ifflag,wdflag,bhflag,remnantflag,mxns,idum
       READ(22,*)pts1,pts2,pts3
-      READ(22,*)sigma,beta,xi,acc2,epsnov,eddfac,gamma
+      READ(22,*)sigma,beta,xi,acc2,epsnov,eddfac,gamma,kickflag
+      READ(22,*)pisn,cekickflag,cehestarflag,grflag,bhms_coll_flag
+      READ(22,*)wd_mass_lim,ecsn,ecsn_mlow,aic,ussn,sigmadiv,bhsigmafrac
+      READ(22,*)don_lim,acc_lim,bdecayfac,bconst,ck,qcflag,eddlimflag
+      READ(22,*)bhspinflag,bhspinmag,rejuv_fac,rejuvflag,htpmb,st_cr
+      READ(22,*)st_tide,rembar_massloss,zsun
+
       if(kstar(1).lt.0.or.kstar(2).lt.0)then
          READ(22,*)tphys
          READ(22,*)aj,mass(1),ospin(1)
@@ -111,11 +117,6 @@
          kstar(2) = ABS(kstar(2))
       else
 
-      WRITE(*,*)mass0(1),mass0(2),tphysf,tb,kstar(1),kstar(2),z,ecc
-      WRITE(*,*)neta,bwind,hewind,alpha1,lambdaf,windflag,rtmsflag
-      WRITE(*,*)ceflag,tflag,ifflag,wdflag,bhflag,remnantflag,mxns,idum
-      WRITE(*,*)pts1,pts2,pts3
-      WRITE(*,*)sigma,beta,xi,acc2,epsnov,eddfac,gamma
 *
 * Initialize the parameters.
 * Set the initial spin of the stars. If ospin is zero (actually < 0.001)
@@ -148,20 +149,8 @@
 * They should really be included in binary.in and copied from an initC
 * file. This is a temporary measure until the input file is updated.
 *
-         pisn = 45.d0
-         cekickflag = 2
-         cehestarflag = 0
-         grflag = 1
-         bhms_coll_flag = 0
-         wd_mass_lim = 1
-         ecsn = 2.25
-         ecsn_mlow = 1.6
-         aic = 1
-         ussn = 0
-         sigmadiv = -20
-         bhsigmafrac = 1.0
-         polar_kick_angle = 90
-         do i = 1,4
+        polar_kick_angle = 90
+        do i = 1,4
             do j = 1,2
                natal_kick_array(j, i) = -100.d0
             enddo
@@ -171,26 +160,9 @@
         do i = 1,8
             qcrit_array(i) = 0.0
         enddo
-        don_lim = -1
-        acc_lim = -1
-        bdecayfac = 1
-        bconst = 3000
-        ck = 1000
-        qcflag = 5
-        eddlimflag = 0
         do i = 1,16
             fprimc_array(i) = 2.0/21.0
         enddo
-        bhspinflag = 0
-        bhspinmag = 0.0
-        rejuv_fac = 1.0
-        rejuvflag = 0
-        htpmb = 1
-        st_cr = 1
-        st_tide = 1
-        rembar_massloss = 0.5
-        zsun = 0.014
-        kickflag = -1
         using_cmc = 0
 
 


### PR DESCRIPTION
This PR does two main things

1. Fix the debugging environment setup to handle the new file structure
2. Add conditions for massless remnants in the kick prescription to avoid NaNs

### NaN stuff

From #687 you can see how NaNs are created after a PISN, which caused hanging in the new Pfahl prescription. I have made two changes

- Add a condition to check for NaN sep values when seeing whether a system is bound (avoids the hanging)
- Add a condition for setting `vk` to a large number when `m1n=0` (since this could create infinite kicks in some prescriptions) - this avoids creating the NaNs in the first place

### Debugging stuff
`.vscode/tasks.json` and `src/cosmic/src/Makefile` needed some changes to paths to ensure everything is compiled in the right place. I also modified `debug/create_binary_in.py` and `src/cosmic/src/test_bse.f` such that all settings are accounted for. Now you can just run something like
```
python create_binary_in.py -f path/to/initC.h5 -b 42
```
Before triggering the debugging routine to run on a particular binary from an initC file (bin_num=42 in this case).

This will fix #687 