### PR TITLE
Metisse variables

### DIFF
--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -584,11 +584,15 @@ def _evolve_single_system(f):
             _evolvebin.se_flags.using_metisse = 0
             _evolvebin.metissevars.path_to_tracks = ""
             _evolvebin.metissevars.path_to_he_tracks = ""
+            _evolvebin.metissevars.z_match_limit = 1e-2
+            _evolvebin.metissevars.METISSE_verbose = False
         elif f["stellar_engine"] == "metisse":
             _evolvebin.se_flags.using_metisse = 1
             _evolvebin.se_flags.using_sse = 0
             _evolvebin.metissevars.path_to_tracks = f["path_to_tracks"]
             _evolvebin.metissevars.path_to_he_tracks = f["path_to_he_tracks"]
+            _evolvebin.metissevars.z_match_limit = 1e-2
+            _evolvebin.metissevars.METISSE_verbose = False
         else:
             raise ValueError("Use either 'sse' or 'metisse' as stellar engine")
 

--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -1174,13 +1174,17 @@ class Sample(object):
         if (SSEDict == None) or (SSEDict["stellar_engine"] == "sse"):
             _evolvebin.se_flags.using_sse = True
             _evolvebin.se_flags.using_metisse = False
-            path_to_tracks = ""
-            path_to_he_tracks = ""
+            _evolvebin.metissevars.path_to_tracks = ""
+            _evolvebin.metissevars.path_to_he_tracks = ""
+            _evolvebin.metissevars.z_match_limit = 1e-2
+            _evolvebin.metissevars.METISSE_verbose = False
         elif SSEDict["stellar_engine"] == "metisse":
             _evolvebin.se_flags.using_metisse = True
             _evolvebin.se_flags.using_sse = False
-            path_to_tracks = SSEDict["path_to_tracks"]
-            path_to_he_tracks = SSEDict["path_to_he_tracks"]
+            _evolvebin.metissevars.path_to_tracks = SSEDict["path_to_tracks"]
+            _evolvebin.metissevars.path_to_he_tracks = SSEDict["path_to_he_tracks"]
+            _evolvebin.metissevars.z_match_limit = 1e-2
+            _evolvebin.metissevars.METISSE_verbose = False
         else:
             raise ValueError("Use either 'sse' or 'metisse' as stellar engine")
             

--- a/src/cosmic/src/METISSE_utils.f90
+++ b/src/cosmic/src/METISSE_utils.f90
@@ -64,9 +64,6 @@
         COMMON/ METISSEVARS/ path_to_tracks,path_to_he_tracks,&
                      z_match_limit, METISSE_verbose
         
-        z_match_limit = 1d-2
-        METISSE_verbose = .false.
-        
         ! remove the null charcater if any
         call get_csafe_string(path_to_tracks,METALLICITY_DIR)
         call get_csafe_string(path_to_he_tracks,METALLICITY_DIR_HE)

--- a/src/cosmic/src/benchmarkevolv2.f
+++ b/src/cosmic/src/benchmarkevolv2.f
@@ -19,7 +19,9 @@
         using_METISSE = 0
         using_SSE = 1
         path_to_tracks = ''
-        path_to_he_tracks = ''      
+        path_to_he_tracks = ''
+        z_match_limit = 1d-2
+        METISSE_verbose = .false.
         kstar(1) = 0.0; kstar(2) = 0.0
         mass(1) = 0.5
         mass(2) = 0.5


### PR DESCRIPTION
Forgot to assign `path_to_tracks` and `path_to_he_tracks` (which are now a part of const_bse.h and the common block metissevars) in independent.py. Added them as well as the other two variables `z_match_limit` and `METISSE_verbose` independent.py and evolve.py. 
The latter two are still hardcoded but in the above two Python files and in benchmarkevolv2.f. 
They are no longer hardcoded in METISSE_utils.f90