### PR TITLE
bugfix (issue 698)

### DIFF
--- a/src/cosmic/src/comenv.f
+++ b/src/cosmic/src/comenv.f
@@ -21,6 +21,21 @@
 *     Update : P. D. Kiel (for ECSN, fallback and bugs)
 *     Date : cmc version mid 2010
 *
+*     Update : V. E. Delfavero (bugs in bpp reporting)
+*     Date : 20th, April 2025
+*
+* Note on indexing binary components:
+*
+* M01, M1, MC1, AJ1, JSPIN1, KW1, formation1, bhspin1 are selected with star1
+* M02, M2, MC2, AJ2, JSPIN2, KW2, formation2, bhspin1 are selected with star2
+*
+* deltam_1 and deltam_2 are calculated before being passed into comenv
+*
+* teff, radc, and ospin are calculated inside comenv (or a function)
+*
+* Other quantities are passed as vectors.
+* These are lumin, menv_bpp, tms, rad, renv, bacc, tacc, epoch, and B_0.
+* tms and rad are immediately separated into tms1/2_bpp and rad1/2_bpp
 *
       INTEGER KW1,KW2,KW,KW1i,KW2i,snp
       INTEGER star1,star2
@@ -305,11 +320,11 @@
      &                       rrl1_bpp,rrl2_bpp,
      &                       aj1_bpp,aj2_bpp,tms1_bpp,tms2_bpp,
      &                       massc1_bpp,massc2_bpp,rad1_bpp,rad2_bpp,
-     &                      M02,M01,lumin(2),lumin(1),teff2,teff1,
-     &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
-     &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
-     &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1,
+     &                      M02,M01,lumin(1),lumin(2),teff1,teff2,
+     &                      RC2,RC1,menv_bpp(1),menv_bpp(2),renv_bpp(1),
+     &                      renv_bpp(2),OSPIN2,OSPIN1,B_0(1),B_0(2),
+     &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                      epoch(2),bhspin2,bhspin1,
      &                      deltam_2,deltam_1,formation2,formation1,
      &                      binstate,mergertype,'bpp')
                    else
@@ -610,11 +625,11 @@
      &                       rrl1_bpp,rrl2_bpp,
      &                       aj1_bpp,aj2_bpp,tms1_bpp,tms2_bpp,
      &                       massc1_bpp,massc2_bpp,rad1_bpp,rad2_bpp,
-     &                      M02,M01,lumin(2),lumin(1),teff2,teff1,
-     &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
-     &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
-     &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1,
+     &                      M02,M01,lumin(1),lumin(2),teff1,teff2,
+     &                      RC2,RC1,menv_bpp(1),menv_bpp(2),renv_bpp(1),
+     &                      renv_bpp(2),OSPIN2,OSPIN1,B_0(1),B_0(2),
+     &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                      epoch(2),bhspin2,bhspin1,
      &                      deltam_2,deltam_1,formation2,formation1,
      &                      binstate,mergertype,'bpp')
                    else
@@ -779,11 +794,11 @@
      &                       rrl1_bpp,rrl2_bpp,
      &                       aj1_bpp,aj2_bpp,tms1_bpp,tms2_bpp,
      &                       massc1_bpp,massc2_bpp,rad1_bpp,rad2_bpp,
-     &                      M02,M01,lumin(2),lumin(1),teff2,teff1,
-     &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
-     &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
-     &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1,
+     &                      M02,M01,lumin(1),lumin(2),teff1,teff2,
+     &                      RC2,RC1,menv_bpp(1),menv_bpp(2),renv_bpp(1),
+     &                      renv_bpp(2),OSPIN2,OSPIN1,B_0(1),B_0(2),
+     &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                      epoch(2),bhspin2,bhspin1,
      &                      deltam_2,deltam_1,formation2,formation1,
      &                      binstate,mergertype,'bpp')
                    else
@@ -1011,11 +1026,11 @@
      &                       rrl1_bpp,rrl2_bpp,
      &                       aj1_bpp,aj2_bpp,tms1_bpp,tms2_bpp,
      &                       massc1_bpp,massc2_bpp,rad1_bpp,rad2_bpp,
-     &                      M02,M01,lumin(2),lumin(1),teff2,teff1,
-     &                      RC2,RC1,menv_bpp(2),menv_bpp(1),renv_bpp(2),
-     &                      renv_bpp(1),OSPIN2,OSPIN1,B_0(2),B_0(1),
-     &                      bacc(2),bacc(1),tacc(2),tacc(1),epoch(2),
-     &                      epoch(1),bhspin2,bhspin1,
+     &                      M02,M01,lumin(1),lumin(2),teff1,teff2,
+     &                      RC2,RC1,menv_bpp(1),menv_bpp(2),renv_bpp(1),
+     &                      renv_bpp(2),OSPIN2,OSPIN1,B_0(1),B_0(2),
+     &                      bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                      epoch(2),bhspin2,bhspin1,
      &                      deltam_2,deltam_1,formation2,formation1,
      &                      binstate,mergertype,'bpp')
                    else


### PR DESCRIPTION
Bugfix addresses https://github.com/COSMIC-PopSynth/COSMIC/issues/698

Corrects a bug where sometimes quantities were reversed in bpp entries for supernova which occur during a common envelope.

-------------------------------------------------------------------------------

Quantities defined individually within the script (M01, M02, etc...) are labeled according to the `j1` and `j2` variables defined in `evolv2.f`. They are reversed in the `writetab` call for the BPP (following a supernova), placing them back in ZAMS order for consistency with `evol_type`

When `evol_type` is 15, the ZAMS primary is undergoing supernova. When 
[test_cosmic_CESN.py.gz](https://github.com/user-attachments/files/19826554/test_cosmic_CESN.py.gz)
it is 16, the ZAMS secondary is undergoing supernova. This requires reporting the ZAMS order of stellar objects in the bpp, rather than the order defined by `j1` and `j2`.

Quantities which are passed to `comenv.f` *as arrays* are always in the order of `ZAMS primary, ZAMS secondary`, and this is already the order for which they should be passed to writetab.

That order should not change as a result of switchedCE, as other quantities do.

I tested this using a script which identifies CE SN in the BPP files as one of the 8 mentioned cases in the issue, and verified that these changes correct the reporting.

I was able to test cases 1b, 2a, 2b, 3a, and 3b. If anybody finds a way to consistently report binaries in the bpp for cases 1a, or 4a/b, I would be happy to test them.

I am also happy to share my script for testing.