### PR TITLE
quick fix to prevent crash in point-mass sampler

### DIFF
--- a/src/cosmic/sample/sampler/cmc.py
+++ b/src/cosmic/sample/sampler/cmc.py
@@ -231,7 +231,7 @@ def get_cmc_sampler(
     singles_table.metallicity = met
     binaries_table.metallicity = met
     singles_table.virial_radius = kwargs.get("virial_radius",1) 
-    singles_table.tidal_radius = kwargs.get("tidal_radius",1e13) 
+    singles_table.tidal_radius = kwargs.get("tidal_radius",1e6) 
     singles_table.central_bh = kwargs.get("central_bh",0)
     singles_table.scale_with_central_bh = kwargs.get("scale_with_central_bh",False)
     singles_table.mass_of_cluster = np.sum(singles_table["m"]) + singles_table.central_bh


### PR DESCRIPTION
Very quick change to fix crash in point-mass clusters.  Changes single number in the CMC initial conditions.