### PR TITLE
fixing the units for the central BH in CMC

### DIFF
--- a/src/cosmic/sample/initialcmctable.py
+++ b/src/cosmic/sample/initialcmctable.py
@@ -303,7 +303,7 @@ class InitialCMCTable(pd.DataFrame):
         # and the attribute mass_of_cluster is None, then
         # we can calculate it now
         if (not Singles.scaled_to_nbody_units) and (Singles.mass_of_cluster is None):
-            Singles.mass_of_cluster = np.sum(Singles["m"]) + central_bh
+            Singles.mass_of_cluster = np.sum(Singles["m"])
             InitialCMCTable.ScaleToNBodyUnits(
                 Singles, Binaries, virial_radius=virial_radius, central_bh=central_bh, scale_with_central_bh=scale_with_central_bh
             )

--- a/src/cosmic/sample/sampler/cmc.py
+++ b/src/cosmic/sample/sampler/cmc.py
@@ -234,7 +234,7 @@ def get_cmc_sampler(
     singles_table.tidal_radius = kwargs.get("tidal_radius",1e6) 
     singles_table.central_bh = kwargs.get("central_bh",0)
     singles_table.scale_with_central_bh = kwargs.get("scale_with_central_bh",False)
-    singles_table.mass_of_cluster = np.sum(singles_table["m"]) + singles_table.central_bh
+    singles_table.mass_of_cluster = np.sum(singles_table["m"])
 
     return singles_table, binaries_table
 

--- a/src/cosmic/sample/sampler/cmc.py
+++ b/src/cosmic/sample/sampler/cmc.py
@@ -335,7 +335,7 @@ def get_cmc_point_mass_sampler(
     singles_table.tidal_radius = kwargs.get("tidal_radius",1e13)
     singles_table.central_bh = kwargs.get("central_bh",0)
     singles_table.scale_with_central_bh = kwargs.get("scale_with_central_bh",False)
-    singles_table.mass_of_cluster = np.sum(singles_table["m"])*size + singles_table.central_bh
+    singles_table.mass_of_cluster = np.sum(singles_table["m"])*size
 
     # Already scaled from the IC generators (unless we've added a central BH)
     if singles_table.central_bh != 0:


### PR DESCRIPTION
Quick fix to make sure the physical units in CMC are correct when including a central massive black hole.  Currently the BH is included in the unit conversions to physical units even though the internal code units do not include it.  This makes these consistent (both internal code units and physical units are only set by the cluster mass, not including the central BH).