### PR TITLE
Fixed tidal radius in CMC point mass sampler

### DIFF
--- a/src/cosmic/sample/sampler/cmc.py
+++ b/src/cosmic/sample/sampler/cmc.py
@@ -332,7 +332,7 @@ def get_cmc_point_mass_sampler(
     singles_table.metallicity = 0.02
     binaries_table.metallicity = 0.02
     singles_table.virial_radius = kwargs.get("virial_radius",1)
-    singles_table.tidal_radius = kwargs.get("tidal_radius",1e13)
+    singles_table.tidal_radius = kwargs.get("tidal_radius",1e6)
     singles_table.central_bh = kwargs.get("central_bh",0)
     singles_table.scale_with_central_bh = kwargs.get("scale_with_central_bh",False)
     singles_table.mass_of_cluster = np.sum(singles_table["m"])*size + singles_table.central_bh


### PR DESCRIPTION
In get_cmc_point_mass_sampler, changed default tidal radius from 1e13 to 1e6 virial radii. This change makes the function consistent with its documentation (and with get_cmc_sampler). This fixes a bug that arose when running isolated Plummer spheres in CMC, where routines to calculate the potential at the tidal radius would fail because the radius was too large.