### PR TITLE
Capture & Recycle zpars for METISSE

### DIFF
--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -32,6 +32,7 @@ import warnings
 import os
 import sys
 import tqdm
+from functools import partial
 from pathlib import Path
 try:
     import multiprocessing
@@ -478,6 +479,9 @@ class Evolve(object):
             initial_conditions[i]["n_col_bcm"] = len(bcm_columns)
             initial_conditions[i]["col_inds_bcm"] = col_inds_bcm
 
+        # evolve one system to get zpars
+        _, _, _, _, _, zpars = _evolve_single_system(initial_conditions[0], None)
+
         # check if a pool was passed
         if pool is None:
             with MultiPool(processes=nproc) as pool:
@@ -493,7 +497,8 @@ class Evolve(object):
                         itr_block = itr_next
                     output = list(pool.map(_evolve_multi_system, initial_conditions_blocked))
                 else:
-                    output = list(pool.map(_evolve_single_system, initial_conditions))
+                    evolve_args = partial(_evolve_single_system, zpars=zpars)
+                    output = list(pool.map(evolve_args, initial_conditions))
         else:
             # evolve systems
             if n_per_block > 0:
@@ -507,7 +512,8 @@ class Evolve(object):
                     itr_block = itr_next
                 output = list(pool.map(_evolve_multi_system, initial_conditions_blocked))
             else:
-                output = list(pool.map(_evolve_single_system, initial_conditions))
+                evolve_args = partial(_evolve_single_system, zpars=zpars)
+                output = list(pool.map(evolve_args, initial_conditions))
 
         output = np.array(output, dtype=object)
         bpp_arrays = np.vstack(output[:, 1])
@@ -549,7 +555,9 @@ class Evolve(object):
         return bpp, bcm, initialbinarytable, kick_info
 
 
-def _evolve_single_system(f):
+def _evolve_single_system(f, zpars=None):
+    if zpars is None:
+        zpars = np.zeros(20, dtype=float)
     try:
         f["kick_info"] = np.zeros((2, len(KICK_COLUMNS)-1))
         # determine if we already have a compact object, if yes than one SN has already occured
@@ -639,7 +647,7 @@ def _evolve_single_system(f):
         _evolvebin.col.n_col_bcm = f["n_col_bcm"]
         _evolvebin.col.col_inds_bcm = f["col_inds_bcm"]
 
-        [bpp_index, bcm_index, kick_info] = _evolvebin.evolv2([f["kstar_1"], f["kstar_2"]],
+        [zpars, bpp_index, bcm_index, kick_info] = _evolvebin.evolv2([f["kstar_1"], f["kstar_2"]],
                                                               [f["mass_1"], f["mass_2"]],
                                                               f["porb"], f["ecc"], f["metallicity"], 
                                                               f["tphysf"], f["dtp"],
@@ -658,7 +666,7 @@ def _evolve_single_system(f):
                                                               [f["tms_1"], f["tms_2"]],
                                                               [f["bhspin_1"], f["bhspin_2"]],
                                                               f["tphys"],
-                                                              np.zeros(20),
+                                                              zpars,
                                                               np.zeros(20),
                                                               f["kick_info"])
                                                               
@@ -674,7 +682,7 @@ def _evolve_single_system(f):
             bcm = np.hstack((bcm, np.ones((bcm.shape[0], 1))*f["bin_num"]))
             kick_info = np.hstack((kick_info, np.ones((kick_info.shape[0], 1))*f["bin_num"]))
 
-        return f, bpp, bcm, kick_info, _evolvebin.snvars.natal_kick_array.copy()
+        return f, bpp, bcm, kick_info, _evolvebin.snvars.natal_kick_array.copy(), zpars
 
     except Exception as e:
         print(e)
@@ -683,6 +691,7 @@ def _evolve_single_system(f):
 
 def _evolve_multi_system(f):
     try:
+        zpars = np.zeros(20, dtype=float)
         res_bcm = np.zeros(f.shape[0], dtype=object)
         res_bpp = np.zeros(f.shape[0], dtype=object)
         res_kick_info = np.zeros(f.shape[0], dtype=object)
@@ -690,7 +699,7 @@ def _evolve_multi_system(f):
         for i in range(0, f.shape[0]):
 
             # call evolve single system
-            _, bpp, bcm, kick_info, _ = _evolve_single_system(f[i])
+            _, bpp, bcm, kick_info, _, zpars = _evolve_single_system(f[i], zpars=zpars)
 
             # add results to pre-allocated list
             res_bpp[i] = bpp

--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -248,6 +248,7 @@ class Evolve(object):
         # NUMBER 1: PASS A DICTIONARY OF FLAGS
         BSEDict = kwargs.pop('BSEDict', {})
         SSEDict = kwargs.pop('SSEDict', {})
+        metisse_metallicity_tolerance = kwargs.pop('metisse_metallicity_tolerance', 1e-6)
 
 
         # NUMBER 2: PASS A PANDAS DATA FRAME WITH PARAMS DEFINED AS COLUMNS
@@ -315,7 +316,8 @@ class Evolve(object):
                 _ = set_metisse_interface(
                     path_to_tracks=SSEDict['path_to_tracks'], 
                     path_to_he_tracks=SSEDict['path_to_he_tracks'],
-                    IBT_Z=initialbinarytable['metallicity'].iloc[0]
+                    IBT_Z=initialbinarytable['metallicity'].iloc[0],
+                    Z_tolerance=metisse_metallicity_tolerance
                     )
 
 
@@ -345,7 +347,8 @@ class Evolve(object):
             _ = set_metisse_interface(
                     path_to_tracks=initialbinarytable['path_to_tracks'].iloc[0], 
                     path_to_he_tracks=initialbinarytable['path_to_he_tracks'].iloc[0],
-                    IBT_Z=initialbinarytable['metallicity'].iloc[0]
+                    IBT_Z=initialbinarytable['metallicity'].iloc[0],
+                    Z_tolerance=metisse_metallicity_tolerance
                     )
             
 
@@ -702,7 +705,7 @@ def _evolve_multi_system(f):
         raise
 
 
-def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z):
+def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z, Z_tolerance):
     """load in the metallicity, format, and eep files
     
     Parameters
@@ -737,30 +740,41 @@ def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z):
     met_dict_keep = None
     fmt_dict_keep = None
     mets = []
-    for m in met_files:
+    Z_idx = -1
+    for i, m in enumerate(met_files):
         met_dict, fmt_dict = utils.read_metallicity_and_format(m)
         mets.append(met_dict['Z_files'])
-        if met_dict['Z_files'] == IBT_Z:
+        if np.abs(met_dict['Z_files'] - IBT_Z) < Z_tolerance:
             met_dict_keep = met_dict
             fmt_dict_keep = fmt_dict
+            Z_idx = i
     if met_dict_keep is None: 
         raise ValueError("No metallicity file found that matches the metallicity "
                          "in the initial binary table. Please check the metallicity "
                          "and supply one that is in this list: {0}".format(mets))
     
-    # loop over the hydrogen metallicity files to find the one that is the closest 
+    # loop over the helium metallicity files to find the one that is the closest 
     # to the metallicity in the initial binary table
     met_dict_he_keep = None
     fmt_dict_he_keep = None
-    for m in met_files_he:
+    Z_idx_he = -1
+    for i, m in enumerate(met_files_he):
         met_dict, fmt_dict = utils.read_metallicity_and_format(m)
-        if met_dict['Z_files'] == IBT_Z:
+        if np.abs(met_dict['Z_files'] - IBT_Z) < Z_tolerance:
             met_dict_he_keep = met_dict
             fmt_dict_he_keep = fmt_dict
+            Z_idx_he = i
+
+    if Z_idx == -1 or Z_idx_he == -1:
+        raise ValueError(f"No metallicities found in range for {IBT_Z}!")
     
     # Convert Python lists to fixed-length NumPy arrays
-    h_eep_np = utils.to_f2py_str_array(h_eep_tracks)
-    he_eep_np = utils.to_f2py_str_array(he_eep_tracks)
+    h_eep_np = []
+    he_eep_np = []
+    for ls in h_eep_tracks:
+        h_eep_np.append(utils.to_f2py_str_array(ls))
+    for ls in he_eep_tracks:
+        he_eep_np.append(utils.to_f2py_str_array(ls))
     met_np = utils.to_f2py_str_array(met_files)
     met_he_np = utils.to_f2py_str_array(met_files_he)
     z_list_h = utils.to_f2py_str_array(met_dict_keep['Z_files'])
@@ -773,8 +787,8 @@ def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z):
     _evolvebin.c_m_interface.set_file_lists(
         met_np,       # met_files
         met_he_np,    # met_he_files
-        h_eep_np,     # h_tracks
-        he_eep_np     # he_tracks
+        h_eep_np[Z_idx],     # h_tracks
+        he_eep_np[Z_idx_he]    # he_tracks
     )
 
     # Next pass the format dictionaries:
@@ -845,10 +859,10 @@ def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z):
     )
 
     # Finally, load in the EEPs! 
-    tracks_h = utils.read_eep_directory(h_eep_tracks)
+    tracks_h = utils.read_eep_directory(h_eep_tracks[Z_idx])
     _ = populate_tracks(tracks_h, is_he=False)
 
-    tracks_he = utils.read_eep_directory(he_eep_tracks)
+    tracks_he = utils.read_eep_directory(he_eep_tracks[Z_idx_he])
     _ = populate_tracks(tracks_he, is_he=True)
 
     return None

--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -240,7 +240,7 @@ Cf2py intent(in) epoch
 Cf2py intent(in) tms
 Cf2py intent(in) bhspin
 Cf2py intent(in) tphys
-Cf2py intent(in) zpars
+Cf2py intent(in,out) zpars
 Cf2py intent(in) bkick
 Cf2py intent(in) kick_info
 Cf2py intent(out) bpp_index_out

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -1944,19 +1944,9 @@ def get_METISSE_files(path_to_tracks, path_to_he_tracks):
     
     path_to_tracks = Path(path_to_tracks)
     path_to_he_tracks = Path(path_to_he_tracks)
-
-    # first find all the EEPs in the specified directories
-    eep_dir = path_to_tracks / "eeps/"
-    he_eep_dir = path_to_he_tracks / "eeps/"
-    h_eep_tracks = [os.path.join(eep_dir, f) for f in os.listdir(eep_dir) if f.endswith("data.eep")]
-    he_eep_tracks = [os.path.join(he_eep_dir, f) for f in os.listdir(he_eep_dir) if f.endswith("data.eep")]
-
-    if len(h_eep_tracks) == 0:
-        raise ValueError("No METISSE tracks found in the specified path: {0}".format(eep_dir))
-    if len(he_eep_tracks) == 0:
-        raise ValueError("No METISSE He tracks found in the specified path: {0}".format(he_eep_dir))
     
-    # Next also get the Metallicity files
+    h_eep_tracks = []
+    he_eep_tracks = []
     met_files = [os.path.join(path_to_tracks, f) for f in os.listdir(path_to_tracks) if f.endswith("metallicity.in")]
     met_files_he = [os.path.join(path_to_he_tracks, f) for f in os.listdir(path_to_he_tracks) if f.endswith("metallicity.in")]
 
@@ -1964,6 +1954,55 @@ def get_METISSE_files(path_to_tracks, path_to_he_tracks):
         raise ValueError("No METISSE metallicity files found in the specified path: {0}".format(path_to_tracks))
     if len(met_files_he) == 0:
         raise ValueError("No METISSE He metallicity files found in the specified path: {0}".format(path_to_he_tracks))
+    
+    for met in met_files:
+        with open(met, "r") as file:
+            lines = file.read().splitlines()
+        eep_path: str | None = None
+        for l in lines:
+            if (l.lower().find("eep_tracks_dir") != -1):
+                eep_path = l.split("=")[-1].strip()[1:-1]
+                break
+        if eep_path is None: raise ValueError(f"No eep_tracks_dir found in {met}. Is this a valid metallicity file?")
+        if eep_path.startswith(os.path.sep):
+            eep_pattern = os.path.join(eep_path, "*.eep")
+        else:
+            eep_pattern = os.path.join(path_to_tracks, eep_path, "*.eep")
+        eeps = glob.glob(eep_pattern)
+        if len(eeps) == 0:
+            raise ValueError(f"No METISSE tracks found in the specified path: {eep_pattern}")
+        h_eep_tracks.append(eeps.copy())
+    for met in met_files_he:
+        with open(met, "r") as file:
+            lines = file.read().splitlines()
+        eep_path: str | None = None
+        for l in lines:
+            if (l.lower().find("eep_tracks_dir") != -1):
+                eep_path = l.split("=")[-1].strip()[1:-1]
+                break
+        if eep_path is None: raise ValueError(f"No eep_tracks_dir found in {met}. Is this a valid metallicity file?")
+        if eep_path.startswith(os.path.sep):
+            eep_pattern = os.path.join(eep_path, "*.eep")
+        else:
+            eep_pattern = os.path.join(path_to_he_tracks, eep_path, "*.eep")
+        eeps = glob.glob(eep_pattern)
+        if len(eeps) == 0:
+            raise ValueError(f"No METISSE tracks found in the specified path: {eep_pattern}")
+        he_eep_tracks.append(eeps.copy())
+    
+    # first find all the EEPs in the specified directories
+    #eep_dir = path_to_tracks #/ "eeps/"
+    #he_eep_dir = path_to_he_tracks #/ "eeps/"
+    #h_eep_tracks = glob.glob(os.path.join(eep_dir, "*.eep"), recursive=True) #[os.path.join(eep_dir, f) for f in os.listdir(eep_dir) if f.endswith("data.eep")]
+    #he_eep_tracks = glob.glob(os.path.join(he_eep_dir, "*.eep"), recursive=True) #[os.path.join(he_eep_dir, f) for f in os.listdir(he_eep_dir) if f.endswith("data.eep")]
+
+    if len(h_eep_tracks) == 0:
+        raise ValueError("No METISSE tracks found in the specified path.") #:{0}".format(eep_dir))
+    if len(he_eep_tracks) == 0:
+        raise ValueError("No METISSE He tracks found in the specified path.")#:{0}".format(he_eep_dir))
+    
+    # Next also get the Metallicity files
+
     
     return h_eep_tracks, he_eep_tracks, met_files, met_files_he
 


### PR DESCRIPTION
This PR adds a mechanism for capturing and recycling zpars from evolv2 when it is called with METISSE. This makes sure we keep zpars for remnant assignment, even if METISSE won't calculate it again between calls to Evolve.evolve.