### PR TITLE
Add `z_accuracy_limit` and `metisse_verbose` to COSMIC & inifile

### DIFF
--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -145,6 +145,14 @@ path_to_tracks = None
 ; Required if stellar_engine = 'metisse'
 path_to_he_tracks = None
 
+; z_accuracy_limit is the maximum allowed relative difference between the supplied metallicity and the tracks
+; used by METISSE. If cosmic throws an error due to metallicity, increasing this slightly may help due to
+; precision errors, etc.
+z_accuracy_limit = 1e-2
+
+; metisse_verbose tells METISSE whether or not to print additional output
+metisse_verbose = False
+
 [bse]
 
 ;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -249,7 +249,6 @@ class Evolve(object):
         # NUMBER 1: PASS A DICTIONARY OF FLAGS
         BSEDict = kwargs.pop('BSEDict', {})
         SSEDict = kwargs.pop('SSEDict', {})
-        z_accuracy_limit = kwargs.pop('METISSE_z_accuracy_limit', 1e-2)
 
 
         # NUMBER 2: PASS A PANDAS DATA FRAME WITH PARAMS DEFINED AS COLUMNS
@@ -295,6 +294,7 @@ class Evolve(object):
             initialbinarytable = initialbinarytable.assign(bin_num=np.arange(idx, idx + len(initialbinarytable)))
 
         if SSEDict:
+            z_accuracy_limit = SSEDict.get("z_accuracy_limit", 1e-2)
             if SSEDict['stellar_engine'] == 'metisse':
                 for k, v in SSEDict.items():
                     if k in initialbinarytable.keys():
@@ -349,7 +349,7 @@ class Evolve(object):
                     path_to_tracks=initialbinarytable['path_to_tracks'].iloc[0], 
                     path_to_he_tracks=initialbinarytable['path_to_he_tracks'].iloc[0],
                     IBT_Z=initialbinarytable['metallicity'].iloc[0],
-                    z_accuracy_limit=z_accuracy_limit
+                    z_accuracy_limit=1e-2
                     )
             
 

--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -307,10 +307,8 @@ def get_independent_sampler(
 
     zsun = kwargs.pop("zsun", 0.02)
 
-    # TODO -- figure out how user can pass this
-    Ztol = 1e-6
-    rad1 = initconditions.set_reff(mass1_binary, metallicity=met, zsun=zsun, SSEDict=SSEDict, metisse_metallicity_tolerance=Ztol)
-    rad2 = initconditions.set_reff(mass2_binary, metallicity=met, zsun=zsun, SSEDict=SSEDict, metisse_metallicity_tolerance=Ztol)
+    rad1 = initconditions.set_reff(mass1_binary, metallicity=met, zsun=zsun, SSEDict=SSEDict)
+    rad2 = initconditions.set_reff(mass2_binary, metallicity=met, zsun=zsun, SSEDict=SSEDict)
 
     # sample periods and eccentricities
     # if the porb_model is moe19, the metallicity needs to be supplied
@@ -1182,8 +1180,6 @@ class Sample(object):
         from cosmic import _evolvebin
         from cosmic.evolve import set_metisse_interface
 
-        z_accuracy_limit = kwargs.get("z_accuracy_limit", 1e-2)
-
         max_array_size = 100000
         total_length = len(mass)
         radii = np.zeros(total_length)
@@ -1198,12 +1194,14 @@ class Sample(object):
             _evolvebin.metissevars.z_match_limit = 1e-2
             _evolvebin.metissevars.METISSE_verbose = False
         elif SSEDict["stellar_engine"] == "metisse":
+            z_accuracy_limit = SSEDict.get("z_accuracy_limit", 1e-2)
+            METISSE_verbose = SSEDict.get("metisse_verbose", False)
             _evolvebin.se_flags.using_metisse = True
             _evolvebin.se_flags.using_sse = False
             _evolvebin.metissevars.path_to_tracks = SSEDict["path_to_tracks"]
             _evolvebin.metissevars.path_to_he_tracks = SSEDict["path_to_he_tracks"]
-            _evolvebin.metissevars.z_match_limit = 1e-2
-            _evolvebin.metissevars.METISSE_verbose = False
+            _evolvebin.metissevars.z_match_limit = z_accuracy_limit
+            _evolvebin.metissevars.METISSE_verbose = METISSE_verbose
             
             _ = set_metisse_interface(
                 path_to_tracks=SSEDict['path_to_tracks'], 

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -1160,6 +1160,22 @@ def error_check(BSEDict, SSEDict, filters=None, convergence=None, sampling=None)
                         SSEDict[flag], flag
                     )
                 )
+    flag = "z_accuracy_limit"
+    if flag in SSEDict.keys():
+        if not isinstance(SSEDict[flag], float):
+            raise ValueError(
+                "`z_accuracy_limit` must be of type `float`. You supplied {0}, which is of type {1}".format(
+                    SSEDict[flag], type(SSEDict[flag])
+                )
+            )
+    flag = "metisse_verbose"
+    if flag in SSEDict.keys():
+        if not isinstance(SSEDict[flag], bool):
+            raise ValueError(
+                "`metisse_verbose` must be of type `bool`. You supplied {0}, which is of type {1}".format(
+                    SSEDict[flag], type(SSEDict[flag])
+                )
+            )
                 
     # BSEDict
     flag = "dtp"


### PR DESCRIPTION
This PR is pretty straightforward. The `z_accuracy_limit` is both passed to `evolvebin.evolv2` and used in the `c_m_interface`. It should calculate the relative metallicity difference the same way METISSE does. Furthermore, I added `metisse_verbose`. although I'm not sure exactly what output that enables or where it is placed. This might be worth following up on. This should address #692.