### PR TITLE
made fileio interface more general

### DIFF
--- a/ci/compile_benchmark.sh
+++ b/ci/compile_benchmark.sh
@@ -10,8 +10,8 @@ FFLAGS="-coverage -fprofile-arcs -ftest-coverage -O0 -J$SRC_DIR -I$SRC_DIR"
 
 # Phase 1: Compile METISSE modules in dependency order
 gfortran $FFLAGS -c \
-    $METISSE_DIR/c_m_interface.f90 \
     $METISSE_DIR/track_support.f90 \
+    $METISSE_DIR/c_m_interface.f90 \
     $METISSE_DIR/z_support.f90 \
     $METISSE_DIR/sse_support.f90 \
     $METISSE_DIR/remnant_support.f90 \

--- a/src/cosmic/evolve.py
+++ b/src/cosmic/evolve.py
@@ -314,13 +314,21 @@ class Evolve(object):
                     raise ValueError("All the metallicities in the initial binary table "
                                      "must be the same if you are using the METISSE stellar engine. ")
             
-                _ = set_metisse_interface(
-                    path_to_tracks=SSEDict['path_to_tracks'], 
-                    path_to_he_tracks=SSEDict['path_to_he_tracks'],
-                    IBT_Z=initialbinarytable['metallicity'].iloc[0],
-                    z_accuracy_limit=z_accuracy_limit
+                # load in the METISSE files
+                _ = read_tracks_for_METISSE(
+                    path_to_tracks = SSEDict['path_to_tracks'], 
+                    IBT_Z = initialbinarytable['metallicity'].iloc[0],
+                    z_accuracy_limit = z_accuracy_limit,
+                    is_he = False
                     )
 
+                if (SSEDict['path_to_he_tracks'] != ''):
+                    _ = read_tracks_for_METISSE(
+                        path_to_tracks = SSEDict['path_to_he_tracks'],
+                        IBT_Z = initialbinarytable['metallicity'].iloc[0], 
+                        z_accuracy_limit = z_accuracy_limit,
+                        is_he = True
+                        )
 
             elif SSEDict['stellar_engine'] == 'sse':    
                 kwargs1 = {'stellar_engine': 'sse'}
@@ -345,11 +353,19 @@ class Evolve(object):
                                  "must be the same if you are using the METISSE stellar engine. ")
             
             # load in the METISSE files
-            _ = set_metisse_interface(
-                    path_to_tracks=initialbinarytable['path_to_tracks'].iloc[0], 
-                    path_to_he_tracks=initialbinarytable['path_to_he_tracks'].iloc[0],
-                    IBT_Z=initialbinarytable['metallicity'].iloc[0],
-                    z_accuracy_limit=z_accuracy_limit
+            _ = read_tracks_for_METISSE(
+                path_to_tracks = SSEDict['path_to_tracks'], 
+                IBT_Z = initialbinarytable['metallicity'].iloc[0],
+                z_accuracy_limit = z_accuracy_limit,
+                is_he = False
+                )
+
+            if (SSEDict['path_to_he_tracks'] != ''):
+                _ = read_tracks_for_METISSE(
+                    path_to_tracks = SSEDict['path_to_he_tracks'],
+                    IBT_Z = initialbinarytable['metallicity'].iloc[0], 
+                    z_accuracy_limit = z_accuracy_limit,
+                    is_he = True
                     )
             
 
@@ -713,171 +729,150 @@ def _evolve_multi_system(f):
         print(e)
         raise
 
+def read_tracks_for_METISSE(path_to_tracks,IBT_Z,z_accuracy_limit,is_he):
 
-def set_metisse_interface(path_to_tracks, path_to_he_tracks, IBT_Z, z_accuracy_limit):
     """load in the metallicity, format, and eep files
     
     Parameters
     ----------
-    path_to_tracks : str or Path
+    path_to_tracks : str
         Direct path to where all single star data and metallicty/format files are stored
         for hydrogen-rich stars
-    
-    path_to_tracks : str or Path
-        Direct path to where all single star data and metallicty/format files are stored
-        for hydrogen-rich stars
-
     IBT_Z : float
         Metallicity from the initialbinarytable
-
+    z_accuracy_limit : float
+        Tolerance for match in metallicity value
+    is_he : bool, default=False
+        Indicates whether the tracks are helium-enriched.
     Returns
     -------
         None
     
     """
 
-    # convert to Path
-    path_to_tracks = Path(path_to_tracks)
-    path_to_he_tracks = Path(path_to_he_tracks)
-
     # load in the METISSE files
-    l = utils.get_METISSE_files(path_to_tracks, path_to_he_tracks)
-    h_eep_tracks, he_eep_tracks, met_files, met_files_he = l
-    
-    # loop over the hydrogen metallicity files to find the one that is the closest 
+    met_files = utils.get_METISSE_metallicity_files(path_to_tracks)
+
+    # loop over the hydrogen metallicity files to find the one that is the closest
     # to the metallicity in the initial binary table
     met_dict_keep = None
     fmt_dict_keep = None
     mets = []
-    Z_idx = -1
     for i, m in enumerate(met_files):
-        met_dict, fmt_dict = utils.read_metallicity_and_format(m)
-        mets.append(met_dict['Z_files'])
-        if abs(met_dict['Z_files'] - IBT_Z)/min(met_dict['Z_files'], IBT_Z) <= z_accuracy_limit:
+        met_dict = utils.read_metallicity_file(m)
+        mets.append(met_dict['z_files'])
+        if abs(met_dict['z_files'] - IBT_Z)/min(met_dict['z_files'], IBT_Z) <= z_accuracy_limit:
             met_dict_keep = met_dict
-            fmt_dict_keep = fmt_dict
+            fmt_dict_keep = utils.read_format_file(met_dict['format_file'])
             Z_idx = i
-    if met_dict_keep is None or fmt_dict_keep is None: 
+    if met_dict_keep is None: 
         raise ValueError("No metallicity file found that matches the metallicity "
                          "in the initial binary table. Please check the metallicity "
                          "and supply one that is in this list: {0}".format(mets))
-    
-    # loop over the helium metallicity files to find the one that is the closest 
-    # to the metallicity in the initial binary table
-    met_dict_he_keep = None
-    fmt_dict_he_keep = None
-    Z_idx_he = -1
-    for i, m in enumerate(met_files_he):
-        met_dict, fmt_dict = utils.read_metallicity_and_format(m)
-        if abs(met_dict['Z_files'] - IBT_Z)/min(met_dict['Z_files'], IBT_Z) <= z_accuracy_limit:
-            met_dict_he_keep = met_dict
-            fmt_dict_he_keep = fmt_dict
-            Z_idx_he = i
-    if met_dict_he_keep is None or fmt_dict_he_keep is None: 
-        raise ValueError("No metallicity file found that matches the metallicity "
-                         "in the initial binary table. Please check the metallicity "
-                         "and supply one that is in this list: {0}".format(mets))
-    
+
+    # PA: it's not needed since metisse is not reading files at all
+
     # Convert Python lists to fixed-length NumPy arrays
-    h_eep_np = []
-    he_eep_np = []
-    for ls in h_eep_tracks:
-        h_eep_np.append(utils.to_f2py_str_array(ls))
-    for ls in he_eep_tracks:
-        he_eep_np.append(utils.to_f2py_str_array(ls))
-    met_np = utils.to_f2py_str_array(met_files)
-    met_he_np = utils.to_f2py_str_array(met_files_he)
-    z_list_h = utils.to_f2py_str_array(met_dict_keep['Z_files'])
-    z_list_he = utils.to_f2py_str_array(met_dict_he_keep['Z_files'])
+    # h_eep_np = []
+    # he_eep_np = []
+    # for ls in h_eep_tracks:
+    #     h_eep_np.append(utils.to_f2py_str_array(ls))
+    # for ls in he_eep_tracks:
+    #     he_eep_np.append(utils.to_f2py_str_array(ls))
+    # met_np = utils.to_f2py_str_array(met_files)
+    # met_he_np = utils.to_f2py_str_array(met_files_he)
+    # z_list_h = utils.to_f2py_str_array(met_dict_keep['Z_files'])
+    # z_list_he = utils.to_f2py_str_array(met_dict_he_keep['Z_files'])
 
-    # Set the metallicity lists in Fortran
-    _evolvebin.c_m_interface.set_mets(z_list_h, z_list_he)
+    # # Set the metallicity lists in Fortran
+    # _evolvebin.c_m_interface.set_mets(z_list_h, z_list_he)
 
-    # Then pass to Fortran; note that f2py seems to get the number files on its own?
-    _evolvebin.c_m_interface.set_file_lists(
-        met_np,       # met_files
-        met_he_np,    # met_he_files
-        h_eep_np[Z_idx],     # h_tracks
-        he_eep_np[Z_idx_he]    # he_tracks
-    )
+    # # Then pass to Fortran; note that f2py seems to get the number files on its own?
+    # _evolvebin.c_m_interface.set_file_lists(
+    #     met_np,       # met_files
+    #     met_he_np,    # met_he_files
+    #     h_eep_np[Z_idx],     # h_tracks
+    #     he_eep_np[Z_idx_he]    # he_tracks
+    # )
 
-    assert fmt_dict_keep is not None and fmt_dict_he_keep is not None
-    # Next pass the format dictionaries:
-    _evolvebin.c_m_interface.set_format_controls_h(
-        read_eep=fmt_dict_keep['read_eep_files'], 
-        prems=fmt_dict_keep['PreMS_EEP'],
-        zams=fmt_dict_keep['ZAMS_EEP'], 
-        iams=fmt_dict_keep['IAMS_EEP'], 
-        tams=fmt_dict_keep['TAMS_EEP'], 
-        bgb=fmt_dict_keep['BGB_EEP'],
-        cheign=fmt_dict_keep['cHeIgnition_EEP'], 
-        cheburn=fmt_dict_keep['cHeBurn_EEP'], 
-        ta_cheb=fmt_dict_keep['TA_cHeB_EEP'], 
-        tpagb=fmt_dict_keep['TPAGB_EEP'], 
-        ccburn=fmt_dict_keep['cCBurn_EEP'], 
-        postagb=fmt_dict_keep['post_AGB_EEP'],
-        initeep=fmt_dict_keep['Initial_EEP'], 
-        finaleep=fmt_dict_keep['Final_EEP'], 
-        fixtrack=fmt_dict_keep['fix_track'], 
-        loweep=fmt_dict_keep['low_mass_final_eep'], 
-        higheep=fmt_dict_keep['high_mass_final_eep'],
-        age_col=fmt_dict_keep['age_colname'],
-        mass_col=fmt_dict_keep['mass_colname'],
-        logl_col=fmt_dict_keep['log_L_colname'],
-        logt_col=fmt_dict_keep['log_T_colname'],
-        logr_col=fmt_dict_keep['log_R_colname'],
-        he_mass_col=fmt_dict_keep['he_core_mass'],
-        co_mass_col=fmt_dict_keep['co_core_mass'],
-        he_radius_col=fmt_dict_keep['he_core_radius'],
-        co_radius_col=fmt_dict_keep['co_core_radius'],
-        mass_env_col=fmt_dict_keep['mass_conv_envelope'],
-        radius_env_col=fmt_dict_keep['radius_conv_envelope'],
-        logtc_col=fmt_dict_keep['log_Tc'],
-        he4_col=fmt_dict_keep['He4_mass_frac'],
-        c12_col=fmt_dict_keep['c12_mass_frac'],
-        o16_col=fmt_dict_keep['o16_mass_frac']
-    )
+    assert fmt_dict_keep is not None 
 
-    # Next pass the format dictionaries:
-    _evolvebin.c_m_interface.set_format_controls_he(
-        read_eep=fmt_dict_he_keep['read_eep_files'], 
-        bgb=fmt_dict_he_keep['BGB_EEP'],
-        cheburn=fmt_dict_he_keep['cHeBurn_EEP'], 
-        ta_cheb=fmt_dict_he_keep['TA_cHeB_EEP'], 
-        tpagb=fmt_dict_he_keep['TPAGB_EEP'], 
-        ccburn=fmt_dict_he_keep['cCBurn_EEP'], 
-        postagb=fmt_dict_he_keep['post_AGB_EEP'],
-        initeep=fmt_dict_he_keep['Initial_EEP'], 
-        finaleep=fmt_dict_he_keep['Final_EEP'], 
-        fixtrack=fmt_dict_he_keep['fix_track'], 
-        loweep=fmt_dict_he_keep['low_mass_final_eep'], 
-        higheep=fmt_dict_he_keep['high_mass_final_eep'],
-        age_col=fmt_dict_he_keep['age_colname'],
-        mass_col=fmt_dict_he_keep['mass_colname'],
-        logl_col=fmt_dict_he_keep['log_L_colname'],
-        logt_col=fmt_dict_he_keep['log_T_colname'],
-        logr_col=fmt_dict_he_keep['log_R_colname'],
-        he_mass_col=fmt_dict_he_keep['he_core_mass'],
-        co_mass_col=fmt_dict_he_keep['co_core_mass'],
-        he_radius_col=fmt_dict_he_keep['he_core_radius'],
-        co_radius_col=fmt_dict_he_keep['co_core_radius'],
-        mass_env_col=fmt_dict_he_keep['mass_conv_envelope'],
-        radius_env_col=fmt_dict_he_keep['radius_conv_envelope'],
-        logtc_col=fmt_dict_he_keep['log_Tc'],
-        he4_col=fmt_dict_he_keep['He4_mass_frac'],
-        c12_col=fmt_dict_he_keep['c12_mass_frac'],
-        o16_col=fmt_dict_he_keep['o16_mass_frac']
-    )
 
-    # Finally, load in the EEPs! 
-    tracks_h = utils.read_eep_directory(h_eep_tracks[Z_idx])
-    _ = populate_tracks(tracks_h, is_he=False)
+    if is_he:
+        # Pass the format dictionaries for helium tracks:
+        _evolvebin.c_m_interface.set_format_controls_he(
+            read_eep=fmt_dict_keep['read_eep_files'],
+            bgb=fmt_dict_keep['bgb_eep'],
+            cheburn=fmt_dict_keep['cheburn_eep'],
+            ta_cheb=fmt_dict_keep['ta_cheb_eep'],
+            tpagb=fmt_dict_keep['tpagb_eep'],
+            ccburn=fmt_dict_keep['ccburn_eep'],
+            postagb=fmt_dict_keep['post_agb_eep'],
+            initeep=fmt_dict_keep['initial_eep'],
+            finaleep=fmt_dict_keep['final_eep'],
+            fixtrack=fmt_dict_keep['fix_track'],
+            loweep=fmt_dict_keep['low_mass_final_eep'],
+            higheep=fmt_dict_keep['high_mass_final_eep'],
+            age_col=fmt_dict_keep['age_colname'],
+            mass_col=fmt_dict_keep['mass_colname'],
+            logl_col=fmt_dict_keep['log_l_colname'],
+            logt_col=fmt_dict_keep['log_t_colname'],
+            logr_col=fmt_dict_keep['log_r_colname'],
+            he_mass_col=fmt_dict_keep['he_core_mass'],
+            co_mass_col=fmt_dict_keep['co_core_mass'],
+            he_radius_col=fmt_dict_keep['he_core_radius'],
+            co_radius_col=fmt_dict_keep['co_core_radius'],
+            mass_env_col=fmt_dict_keep['mass_conv_envelope'],
+            radius_env_col=fmt_dict_keep['radius_conv_envelope'],
+            logtc_col=fmt_dict_keep['log_tc'],
+            he4_col=fmt_dict_keep['he4_mass_frac'],
+            c12_col=fmt_dict_keep['c12_mass_frac'],
+            o16_col=fmt_dict_keep['o16_mass_frac']
+        )
+    else:
+        # Pass the format dictionaries:
+        _evolvebin.c_m_interface.set_format_controls_h(
+            read_eep=fmt_dict_keep['read_eep_files'],
+            prems=fmt_dict_keep['prems_eep'],
+            zams=fmt_dict_keep['zams_eep'],
+            iams=fmt_dict_keep['iams_eep'],
+            tams=fmt_dict_keep['tams_eep'],
+            bgb=fmt_dict_keep['bgb_eep'],
+            cheign=fmt_dict_keep['cheignition_eep'],
+            cheburn=fmt_dict_keep['cheburn_eep'],
+            ta_cheb=fmt_dict_keep['ta_cheb_eep'],
+            tpagb=fmt_dict_keep['tpagb_eep'],
+            ccburn=fmt_dict_keep['ccburn_eep'],
+            postagb=fmt_dict_keep['post_agb_eep'],
+            initeep=fmt_dict_keep['initial_eep'],
+            finaleep=fmt_dict_keep['final_eep'],
+            fixtrack=fmt_dict_keep['fix_track'],
+            loweep=fmt_dict_keep['low_mass_final_eep'],
+            higheep=fmt_dict_keep['high_mass_final_eep'],
+            age_col=fmt_dict_keep['age_colname'],
+            mass_col=fmt_dict_keep['mass_colname'],
+            logl_col=fmt_dict_keep['log_l_colname'],
+            logt_col=fmt_dict_keep['log_t_colname'],
+            logr_col=fmt_dict_keep['log_r_colname'],
+            he_mass_col=fmt_dict_keep['he_core_mass'],
+            co_mass_col=fmt_dict_keep['co_core_mass'],
+            he_radius_col=fmt_dict_keep['he_core_radius'],
+            co_radius_col=fmt_dict_keep['co_core_radius'],
+            mass_env_col=fmt_dict_keep['mass_conv_envelope'],
+            radius_env_col=fmt_dict_keep['radius_conv_envelope'],
+            logtc_col=fmt_dict_keep['log_tc'],
+            he4_col=fmt_dict_keep['he4_mass_frac'],
+            c12_col=fmt_dict_keep['c12_mass_frac'],
+            o16_col=fmt_dict_keep['o16_mass_frac']
+        )
 
-    tracks_he = utils.read_eep_directory(he_eep_tracks[Z_idx_he])
-    _ = populate_tracks(tracks_he, is_he=True)
+    # Finally, load in the EEPs!
+    track_list = utils.read_eep_directory(
+                met_dict_keep['eep_tracks_dir'],
+                fmt_dict_keep)
+    _ = populate_tracks(track_list,is_he)
+    return
 
-    return None
-    
 
 def populate_tracks(track_list, is_he=False):
     """
@@ -901,8 +896,6 @@ def populate_tracks(track_list, is_he=False):
             - 'eep' : array-like of shape (neep,)
             - 'tr' : array-like of shape (ncol, ntrack)
             - 'cols' : list of str of length ncol
-        Optional key:
-            - 'is_he_track' : bool
 
     is_he : bool, default=False
         Indicates whether the tracks are helium-enriched.
@@ -928,7 +921,6 @@ def populate_tracks(track_list, is_he=False):
     ntrack_arr = np.array([t['ntrack'] for t in track_list], dtype=np.int32)
     neep_arr = np.array([t['neep'] for t in track_list], dtype=np.int32)
     ncol_arr = np.array([t['ncol'] for t in track_list], dtype=np.int32)
-    is_he_arr = np.array([t.get('is_he_track', is_he) for t in track_list], dtype=np.bool_)
 
     # Determine max sizes
     max_neep = max(neep_arr)
@@ -936,6 +928,9 @@ def populate_tracks(track_list, is_he=False):
     max_ntrack = sum(ntrack_arr)
 
     # Prepare 2D arrays
+
+    if max_neep<0:
+        max_neep = 0
     eep_data = np.zeros((max_neep, ntracks), dtype=np.int32, order='F')
     tr_data = np.zeros((max_ncol, max_ntrack), dtype=np.float64, order='F')
     col_names = np.full((max_ncol, ntracks), b' ' * col_width, dtype=f'S{col_width}', order='F')
@@ -943,18 +938,19 @@ def populate_tracks(track_list, is_he=False):
     # Fill arrays
     offset = 0
     for i, t in enumerate(track_list):
-        eep_data[:t['neep'], i] = t['eep']
+        if max_neep>0:
+            eep_data[:t['neep'], i] = t['eep']
         tr_data[:t['ncol'], offset:offset+t['ntrack']] = t['tr']
+
         for j, col in enumerate(t['cols']):
             s = col.encode('ascii')[:col_width]      # truncate if too long
             col_names[j, i] = s.ljust(col_width, b' ')  # pad with spaces
         offset += t['ntrack']
 
-    # Call Fortran
     _evolvebin.c_m_interface.set_tracks_from_python(
         filenames, initial_mass, initial_Y, initial_Z,
         Fe_div_H, alpha_div_Fe, v_div_vcrit,
-        ntrack_arr, neep_arr, ncol_arr, is_he_arr,
+        ntrack_arr, neep_arr, ncol_arr, 
         eep_data, tr_data, col_names, is_he
     )
 

--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -1178,7 +1178,7 @@ class Sample(object):
         """
 
         from cosmic import _evolvebin
-        from cosmic.evolve import set_metisse_interface
+        from cosmic.evolve import read_tracks_for_METISSE
 
         max_array_size = 100000
         total_length = len(mass)
@@ -1203,7 +1203,7 @@ class Sample(object):
             _evolvebin.metissevars.z_match_limit = z_accuracy_limit
             _evolvebin.metissevars.METISSE_verbose = METISSE_verbose
             
-            _ = set_metisse_interface(
+            _ = read_tracks_for_METISSE(
                 path_to_tracks=SSEDict['path_to_tracks'], 
                 path_to_he_tracks=SSEDict['path_to_he_tracks'],
                 IBT_Z=metallicity,

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -63,9 +63,11 @@ __all__ = [
     "get_binfrac_of_Z",
     "get_porb_norm",
     "get_met_dep_binfrac",
-    "get_METISSE_files",
-    "read_metallicity_and_format",
-    "read_eep_file",
+    "get_METISSE_metallicity_files",
+    "read_metallicity_file",
+    "read_format_file",
+    "rread_MIST_track",
+    "read_other_track",
     "read_eep_directory",
     "to_f2py_str_array"
 ]
@@ -1919,97 +1921,35 @@ def parse_inifile(inifile):
 
     return BSEDict, SSEDict, seed_int, filters, convergence, sampling
 
-def get_METISSE_files(path_to_tracks, path_to_he_tracks):
+def get_METISSE_metallicity_files(path_to_tracks):
     """Returns the path to the METISSE files
     
     Parameters
     ----------
     path_to_tracks : str
-        Path to the directory containing the METISSE tracks.
-    path_to_he_tracks : str
-        Path to the directory containing the METISSE He tracks.
+        Path to the directory containing the METISSE metallicity file(s) for hydrogen/helium tracks
     
     Returns
     -------
-    eep_tracks : list
-        List of paths to the METISSE EEP tracks
-    he_eep_tracks : list
-        List of paths to the METISSE helium EEP tracks
     met_files : list
-        List of paths to the METISSE metallicity files for hydrogen tracks
-    met_files_he : list
-        List of paths to the METISSE He metallicity files for helium trakcs
+        List of paths to the METISSE metallicity files for hydrogen/helium tracks
     """
     import os
-    
+
     path_to_tracks = Path(path_to_tracks)
-    path_to_he_tracks = Path(path_to_he_tracks)
-    
-    h_eep_tracks = []
-    he_eep_tracks = []
+
+    # Next also get the Metallicity files
     met_files = [os.path.join(path_to_tracks, f) for f in os.listdir(path_to_tracks) if f.endswith("metallicity.in")]
-    met_files_he = [os.path.join(path_to_he_tracks, f) for f in os.listdir(path_to_he_tracks) if f.endswith("metallicity.in")]
 
     if len(met_files) == 0:
         raise ValueError("No METISSE metallicity files found in the specified path: {0}".format(path_to_tracks))
-    if len(met_files_he) == 0:
-        raise ValueError("No METISSE He metallicity files found in the specified path: {0}".format(path_to_he_tracks))
-    
-    for met in met_files:
-        with open(met, "r") as file:
-            lines = file.read().splitlines()
-        eep_path: str | None = None
-        for l in lines:
-            if (l.lower().find("eep_tracks_dir") != -1):
-                eep_path = l.split("=")[-1].strip()[1:-1]
-                break
-        if eep_path is None: raise ValueError(f"No eep_tracks_dir found in {met}. Is this a valid metallicity file?")
-        if eep_path.startswith(os.path.sep):
-            eep_pattern = os.path.join(eep_path, "*.eep")
-        else:
-            eep_pattern = os.path.join(path_to_tracks, eep_path, "*.eep")
-        eeps = glob.glob(eep_pattern)
-        if len(eeps) == 0:
-            raise ValueError(f"No METISSE tracks found in the specified path: {eep_pattern}")
-        h_eep_tracks.append(eeps.copy())
-    for met in met_files_he:
-        with open(met, "r") as file:
-            lines = file.read().splitlines()
-        eep_path: str | None = None
-        for l in lines:
-            if (l.lower().find("eep_tracks_dir") != -1):
-                eep_path = l.split("=")[-1].strip()[1:-1]
-                break
-        if eep_path is None: raise ValueError(f"No eep_tracks_dir found in {met}. Is this a valid metallicity file?")
-        if eep_path.startswith(os.path.sep):
-            eep_pattern = os.path.join(eep_path, "*.eep")
-        else:
-            eep_pattern = os.path.join(path_to_he_tracks, eep_path, "*.eep")
-        eeps = glob.glob(eep_pattern)
-        if len(eeps) == 0:
-            raise ValueError(f"No METISSE tracks found in the specified path: {eep_pattern}")
-        he_eep_tracks.append(eeps.copy())
-    
-    # first find all the EEPs in the specified directories
-    #eep_dir = path_to_tracks #/ "eeps/"
-    #he_eep_dir = path_to_he_tracks #/ "eeps/"
-    #h_eep_tracks = glob.glob(os.path.join(eep_dir, "*.eep"), recursive=True) #[os.path.join(eep_dir, f) for f in os.listdir(eep_dir) if f.endswith("data.eep")]
-    #he_eep_tracks = glob.glob(os.path.join(he_eep_dir, "*.eep"), recursive=True) #[os.path.join(he_eep_dir, f) for f in os.listdir(he_eep_dir) if f.endswith("data.eep")]
 
-    if len(h_eep_tracks) == 0:
-        raise ValueError("No METISSE tracks found in the specified path.") #:{0}".format(eep_dir))
-    if len(he_eep_tracks) == 0:
-        raise ValueError("No METISSE He tracks found in the specified path.")#:{0}".format(he_eep_dir))
-    
-    # Next also get the Metallicity files
-
-    
-    return h_eep_tracks, he_eep_tracks, met_files, met_files_he
+    return met_files
 
 
-def read_metallicity_and_format(met_file_path):
+def read_metallicity_file(met_file_path):
     """
-    Read a metallicity namelist and its associated format file.
+    Read a metallicity namelist 
 
     Parameters
     ----------
@@ -2021,8 +1961,6 @@ def read_metallicity_and_format(met_file_path):
     met_dict : dict
         Dictionary containing metallicity options, e.g., 
         'eep_tracks_dir', 'Z_files', 'format_file', etc. Paths are converted to Path objects.
-    fmt_dict : dict
-        Dictionary containing format file options, e.g., column names, EEP stages, flags.
 
     Notes
     -----
@@ -2034,7 +1972,19 @@ def read_metallicity_and_format(met_file_path):
     met_file_path = Path(met_file_path)
     
     # --- Read metallicity file ---
-    met_dict = {}
+    met_dict = {
+    "eep_tracks_dir": "",
+    "Z_files": -1.0,
+    "format_file": "",
+    "Y_files": -1.0,
+    "Mhook": -1.0,
+    "Mhef": -1.0,
+    "Mfgb": -1.0,
+    "Mup": -1.0,
+    "Mec": -1.0,
+    "Mextra": -1.0
+    }
+
     with open(met_file_path, 'r') as f:
         for line in f:
             line = line.split('!')[0].strip()  # remove comments
@@ -2053,15 +2003,95 @@ def read_metallicity_and_format(met_file_path):
                 except ValueError:
                     met_dict[key] = value.strip("'\"")  # keep strings
     
-    # Convert paths to Path objects relative to metallicity file
+    # Check if the paths exist
     if 'eep_tracks_dir' in met_dict:
-        met_dict['eep_tracks_dir'] = met_file_path.parent / met_dict['eep_tracks_dir']
+        if os.path.exists(met_dict['eep_tracks_dir']) is False:
+            # Otherwise convert paths to Path objects relative to metallicity file
+            # met_dict['eep_tracks_dir'] = os.path.join(met_file_path.parent,met_dict['eep_tracks_dir'])
+            met_dict['eep_tracks_dir'] = met_file_path.parent / met_dict['eep_tracks_dir']
+    else:
+        raise ValueError("eep_tracks_dir not found in {0}".format (met_file_path))
     if 'format_file' in met_dict:
-        met_dict['format_file'] = met_file_path.parent / met_dict['format_file']
+        if os.path.exists(met_dict['format_file']) is False:
+            met_dict['format_file'] = met_file_path.parent / met_dict['format_file']
+    else:
+        raise ValueError("format_file not found in {0}".format (met_file_path))
     
-    # --- Read format file ---
-    fmt_dict = {}
-    format_file_path = met_dict['format_file']
+    met_dict = {k.lower(): v for k, v in met_dict.items()}
+
+    return met_dict
+
+def read_format_file(format_file_path):
+    """
+    Read the format file associated with the metallicity namelist 
+
+    Parameters
+    ----------
+    format_file_path : str or Path
+        Path to the format file.
+
+    Returns
+    -------
+    fmt_dict : dict
+        Dictionary containing format file options, e.g., column names, EEP stages, flags.
+
+    Notes
+    -----
+    - Booleans (.true./.false.) are converted to Python True/False.
+    - Fortran-style scientific notation with 'd' (e.g., 1.23d-04) is converted to float.
+    - Strings in quotes are stripped of the quotes.
+    - Stops parsing at the Fortran namelist terminator '/'.
+    """
+
+# --- Read format file ---
+    fmt_dict = {
+    "read_eep_files": False,
+    "file_extension": "",
+    "header_location": -1,
+    "extra_char": "",
+    "column_name_file": "",
+    "total_cols": -1,
+    "age_colname": "",
+    "mass_colname": "",
+    "log_L_colname": "",
+    "Lum_colname": "",
+    "log_R_colname": "",
+    "Radius_colname": "",
+    "he_core_mass": "",
+    "co_core_mass": "",
+    "binding_energy_colname": "",
+    "he_core_radius": "",
+    "co_core_radius": "",
+    "mass_conv_envelope": "",
+    "radius_conv_envelope": "",
+    "log_T_colname": "",
+    "Teff_colname": "",
+    "log_Tc": "",
+    "he4_mass_frac": "",
+    "c12_mass_frac": "",
+    "o16_mass_frac": "",
+    "PreMS_EEP": -1,
+    "ZAMS_EEP": -1,
+    "IAMS_EEP": -1,
+    "TAMS_EEP": -1,
+    "BGB_EEP": -1,
+    "cHeIgnition_EEP": -1,
+    "cHeBurn_EEP": -1,
+    "TA_cHeB_EEP": -1,
+    "TPAGB_EEP": -1,
+    "cCBurn_EEP": -1,
+    "post_AGB_EEP": -1,
+    "Initial_EEP": -1,
+    "Final_EEP": -1,
+    "Extra_EEP1": -1,
+    "Extra_EEP2": -1,
+    "Extra_EEP3": -1,
+    "low_mass_final_eep": -1,
+    "high_mass_final_eep": -1,
+    "fix_track": True,
+    "lookup_index": 1.0
+    }
+
     with open(format_file_path, 'r') as f:
         for line in f:
             line = line.split('!')[0].strip()
@@ -2093,10 +2123,14 @@ def read_metallicity_and_format(met_file_path):
                     except ValueError:
                         fmt_dict[key] = value  # fallback
     
-    return met_dict, fmt_dict
+    # Convert all keys in fmt_dict_keep to lowercase
+    fmt_dict = {k.lower(): v for k, v in fmt_dict.items()}
+
+    return fmt_dict
 
 
-def read_eep_file(eep_path):
+
+def read_MIST_track(eep_path):
     track = {}
     track['filename'] = str(eep_path)
 
@@ -2127,14 +2161,14 @@ def read_eep_file(eep_path):
         info_line = f.readline()
         track['initial_mass'] = float(info_line[2:18].strip())
         track['ntrack'] = int(info_line[18:26].strip())
-        track['neep'] = int(info_line[26:34].strip())
         track['ncol'] = int(info_line[34:42].strip())
-        track['phase_info'] = info_line[42:50].strip()
+        # track['phase_info'] = info_line[42:50].strip()
         track['type_label'] = info_line[50:65].strip()
 
         # EEP lines
         eep_line = f.readline()
         track['eep'] = np.array([int(x) for x in eep_line.split()[2:]], dtype=int)
+        track['neep'] = len(track['eep'])
 
         f.readline()  # comment line
         f.readline()  # column numbers line
@@ -2144,43 +2178,100 @@ def read_eep_file(eep_path):
         track['cols'] = cols_line.split()[1:]  # list of strings start at 1 to skip # symbol
 
         # track data
-        tr = np.zeros((track['ncol'], track['ntrack']), dtype=float)
-        for j in range(track['ntrack']):
-            data_line = f.readline()
-            values = [float(x) for x in data_line.split()]
-            tr[:, j] = values[:track['ncol']]
-        track['tr'] = tr
+        # tr = np.zeros((track['ncol'], track['ntrack']), dtype=float)
+        # for j in range(track['ntrack']):
+        #     data_line = f.readline()
+        #     values = [float(x) for x in data_line.split()]
+        #     tr[:, j] = values[:track['ncol']]
+        # track['tr'] = tr
+        # track data
+        track['tr'] = np.loadtxt(eep_path, skiprows = 11,dtype=float) 
+        track['tr'] = np.transpose(track['tr']) 
+        track['ncol'], track['ntrack'] = track['tr'].shape
+    return track
+
+def read_other_track(eep_path,fmt):
+    track = {}
+    track['filename'] = str(eep_path)
+    header = fmt['header_location']
+
+    # track data
+    track['tr'] = np.loadtxt(eep_path, skiprows = header, dtype=float) 
+    track['tr'] = np.transpose(track['tr']) 
+    track['ncol'], track['ntrack'] = track['tr'].shape
+    # Set the following values to defaults
+    # they are either not relevant at this point 
+    # or are assigned later within METISSE
+    track['initial_mass'] = -1.0
+    track['initial_Y'] = -1.0
+    track['initial_Z'] = -1.0
+    track['Fe_div_H'] = -1.0
+    track['alpha_div_Fe'] = -1.0
+    track['v_div_vcrit'] = -1.0
+    track['neep'] = 0
+
+    with eep_path.open() as f:
+        # Read lines sequentially to mimic Fortran
+        if header>0:
+            for i in range(header-1):
+                f.readline()
+            # Column names line
+            track['cols'] = f.readline().strip().split() 
+            # remove any extra chracter (such as #) if present
+            track['cols'] = [c for c in track['cols'] if c != fmt['extra_char']]
+        else:
+            if os.path.exists(fmt["column_name_file"]):
+                #read the column name file
+                with open(fmt["column_name_file"], "r") as f:
+                    track['cols'] = [line.strip() for line in f if line.strip()]
+                    if (len(track['cols']) != track['ncol']):
+                        raise ValueError(
+                            "Total columns {0} in the column_name_file do not match the number of columns {1} in the eep file".format(
+                                len(track['cols']), track['ncol'])
+                            )
+            else:
+                raise ValueError(
+                        "Check if header location {0} and column_name_file {1} are correct".format(
+                            header, fmt["column_name_file"])
+                            )
 
     return track
 
-
-
-def read_eep_directory(eep_files, pattern="*.eep"):
+def read_eep_directory(eep_dir,fmt_dict):
     """
-    Read all EEP files in a directory matching the given pattern and sort by
-    the leading number in the filename.
+    Read all EEP files in a directory matching the given pattern 
 
     Parameters
     ----------
-    eep_files : list
-        list of all files in the eep directory
+    eep_dir : str or Path
+        Directory containing the EEP files.
+
+    fmt_dict : dict
+        Dictionary containing format file options, e.g., column names, EEP stages, flags.
 
     Returns
     -------
     tracks : list of dict
-        List of track dictionaries, each as returned by `read_eep_file`,
-        sorted by the leading number in the filename.
+        List of track dictionaries, each as returned by `read_eep_file`
     """
-    # Convert all to Path objects
-    eep_files = [Path(f) for f in eep_files]
 
-    # Sort files by the leading number in the filename
-    def extract_mass(f):
-        # Get the first integer before the first underscore
-        return int(f.stem.split('_')[0])
+    eep_dir = Path(eep_dir)
 
-    eep_files_sorted = sorted(eep_files, key=extract_mass)
-    tracks = [read_eep_file(f) for f in eep_files_sorted]
+
+    if fmt_dict['read_eep_files']:
+        pattern="*.eep"
+    else:
+        pattern = "*"+fmt_dict['file_extension']
+
+    eep_files = list(eep_dir.glob(pattern))
+
+    if len(eep_files) == 0:
+        raise ValueError("No eep tracks found in the specified path: {0}".format(eep_dir))
+
+    if fmt_dict['read_eep_files']:
+        tracks = [read_MIST_track(f) for f in eep_files]
+    else:
+        tracks = [read_other_track(f,fmt_dict) for f in eep_files]
     return tracks
 
 

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -66,7 +66,7 @@ __all__ = [
     "get_METISSE_metallicity_files",
     "read_metallicity_file",
     "read_format_file",
-    "rread_MIST_track",
+    "read_MIST_track",
     "read_other_track",
     "read_eep_directory",
     "to_f2py_str_array"

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -1130,7 +1130,7 @@ def error_check(BSEDict, SSEDict, filters=None, convergence=None, sampling=None)
                 )
             else:
                 path = Path(SSEDict[flag])
-                metallicity_file = list(path.glob('*_metallicity.in'))
+                metallicity_file = list(path.glob('[!.]*_metallicity.in'))
                 if metallicity_file == []:
                     raise ValueError(
                         "No metallicity file found in {0}. Make sure that {1} is valid".format (
@@ -1155,7 +1155,7 @@ def error_check(BSEDict, SSEDict, filters=None, convergence=None, sampling=None)
                 )
             else:
                 path = Path(SSEDict[flag])
-                metallicity_file = list(path.glob('*_metallicity.in'))
+                metallicity_file = list(path.glob('[!.]*_metallicity.in'))
                 if metallicity_file == []:
                     raise ValueError(
                         "No metallicity file for helium star tracks found in {0}. Make sure that {1} is valid".format (


### PR DESCRIPTION
The python interface for reading files before could only handle specific kinds of files. Made it more general and also more robust. For example, there were issues with case between python and Fortran namelists. They are now dealt converting everything to lowercase in python. Also there were no defaults for the format and the metallicity namelists. Missing values would break the code. 
