### PR TITLE
Update COSMIC-METISSE interface functions in utils / independent sampler

### DIFF
--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -1205,10 +1205,17 @@ class Sample(object):
             
             _ = read_tracks_for_METISSE(
                 path_to_tracks=SSEDict['path_to_tracks'], 
-                path_to_he_tracks=SSEDict['path_to_he_tracks'],
                 IBT_Z=metallicity,
-                z_accuracy_limit=z_accuracy_limit
+                z_accuracy_limit=z_accuracy_limit,
+                is_he=False
                 )
+            if (SSEDict['path_to_he_tracks'] != ''):
+                _ = read_tracks_for_METISSE(
+                    path_to_tracks=SSEDict['path_to_he_tracks'], 
+                    IBT_Z=metallicity,
+                    z_accuracy_limit=z_accuracy_limit,
+                    is_he=True
+                    )
         else:
             raise ValueError("Use either 'sse' or 'metisse' as stellar engine")
             

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -2202,7 +2202,9 @@ def read_MIST_track(eep_path):
         # track['tr'] = tr
         # track data
         track['tr'] = np.loadtxt(eep_path, skiprows = 11,dtype=float) 
-        track['tr'] = np.transpose(track['tr']) 
+        track['tr'] = np.transpose(track['tr'])
+        if len(track['tr'].shape) < 2:
+            track['tr'] = track['tr'].reshape((-1, 1))
         track['ncol'], track['ntrack'] = track['tr'].shape
     return track
 


### PR DESCRIPTION
This is a quick addendum to #721 which updates the function calls in the independent sampler to match the new signatures (i.e. one call for "path_to_tracks", and another optional one for "path_to_he_tracks").