### PR TITLE
Smarter initC IO

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,3 +55,7 @@ See the discussed changes in our previous releases here: https://github.com/COSM
 ## 3.6.1
  - Add support for single stars in both independent and multidim sampling
  - update documentation
+
+## 3.6.2
+ - Add functions to `cosmic.utils` for initC IO that's more efficient (`save_initC`, `load_initC`) by saving
+ identical setting columns separately with only one copy - saves ~1kb per binary

--- a/docs/cosmic-settings.json
+++ b/docs/cosmic-settings.json
@@ -957,7 +957,7 @@
                 ]
             },
             {
-                "name": "ecsn_low",
+                "name": "ecsn_mlow",
                 "description": "Sets the low end of the ECSN mass range",
                 "type": "number",
                 "options-preface": "",

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -29,6 +29,7 @@ import operator
 import json
 import itertools
 import os.path
+import h5py as h5
 
 from configparser import ConfigParser
 from .bse_utils.zcnsts import zcnsts
@@ -37,6 +38,7 @@ __author__ = "Katelyn Breivik <katie.breivik@gmail.com>"
 __credits__ = [
     "Scott Coughlin <scott.coughlin@ligo.org>",
     "Michael Zevin <zevin@northwestern.edu>",
+    "Tom Wagg <tomjwagg@gmail.com>",
 ]
 __all__ = [
     "filter_bin_state",
@@ -52,6 +54,8 @@ __all__ = [
     "check_initial_conditions",
     "convert_kstar_evol_type",
     "parse_inifile",
+    "save_initC",
+    "load_initC",
     "pop_write",
     "a_from_p",
     "p_from_a",
@@ -60,6 +64,7 @@ __all__ = [
     "get_binfrac_of_Z",
     "get_porb_norm",
     "get_met_dep_binfrac"
+
 ]
 
 
@@ -346,6 +351,77 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
         conv_lims_bin_num = conv_save.bin_num
 
     return conv_save, conv_lims_bin_num
+
+
+def save_initC(filename, initC, key="initC", settings_key="initC_settings", force_save_all=False):
+    """Save an initC table to an HDF5 file.
+
+    Any column where every binary has the same value (setting) is saved separately with only a single copy
+    to save space.
+
+    This will take slightly longer (a few seconds instead of 1 second) to run but will save you around
+    a kilobyte per binary, which adds up!
+
+    Parameters
+    ----------
+    filename : `str`
+        Filename/path to the HDF5 file
+    initC : `pandas.DataFrame`
+        Initial conditions table
+    key : `str`, optional
+        Dataset key to use for main table, by default "initC"
+    settings_key : `str`, optional
+        Dataset key to use for settings table, by default "initC_settings"
+    force_save_all : `bool`, optional
+        If true, force all settings columns to be saved in the main table, by default False
+    """
+
+    # for each column, check if all values are the same
+    uniques = initC.nunique(axis=0)
+    compress_cols = [col for col in initC.columns if uniques[col] == 1]
+
+    if len(compress_cols) == 0 or force_save_all:
+        # nothing to compress, just save the whole table
+        initC.to_hdf(filename, key=key)
+    else:
+        # save the main table without the compressed columns
+        initC.drop(columns=compress_cols).to_hdf(filename, key=key)
+
+        # save the compressed columns separately
+        settings_df = pd.DataFrame([{col: initC[col].iloc[0] for col in compress_cols}])
+        settings_df.to_hdf(filename, key=settings_key)
+
+
+def load_initC(filename, key="initC", settings_key="initC_settings"):
+    """Load an initC table from an HDF5 file.
+
+    If settings were saved separately, they are merged back into the main table.
+
+    Parameters
+    ----------
+    filename : `str`
+        Filename/path to the HDF5 file
+    key : `str`, optional
+        Dataset key to use for main table, by default "initC"
+    settings_key : `str`, optional
+        Dataset key to use for settings table, by default "initC_settings"
+
+    Returns
+    -------
+    initC : `pandas.DataFrame`
+        Initial conditions table
+    """
+
+    with h5.File(filename, 'r') as f:
+        has_settings = settings_key in f.keys()
+
+    initC = pd.read_hdf(filename, key=key)
+
+    if has_settings:
+        settings_df = pd.read_hdf(filename, key=settings_key)
+        initC.loc[:, settings_df.columns] = settings_df.values[0]
+
+    return initC
 
 
 def pop_write(


### PR DESCRIPTION
This PR will save ~1Kb per binary when saving an initC file without hugely affecting the runtime - that's a Gb per million binaries!

Identical columns are saved separately with a single row instead of N rows.
Hopefully the keyword args and docstrings are self-explanatory but typical usage is
```
...run COSMIC sim
save_initC("path/to/file.h5", initC)
loaded_initC = load_initC("path/to/file.h5")
```
instead of
```
.to_hdf() and pd.read_hdf()
```