### PR TITLE
Update cosmic-pop

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -120,8 +120,8 @@ def parse_commandline():
                                              " to select the subpopulation of interest from the evolved population")
     parser.add_argument("--match", type=float, help="provides the tolerance for the convergence calculation")
     parser.add_argument("--apply_convergence_limits", type=str2bool, nargs='?',
-                        const=True, default=False, help="filters the evolved binary population to contain"
-                                                        " only the binaries that satsify the convergence limits")
+                        const=True, help="filters the evolved binary population to contain"
+                                                        " only the binaries that satisfy the convergence limits")
     parser.add_argument("--seed", type=int)
     parser.add_argument("--verbose", action="store_true", default=False,
                         help="Run in Verbose Mode")


### PR DESCRIPTION
Removed the default for apply-convergence-limits because it is already defined in Params.ini. Otherwise, cosmic-pop throws an error about conflicting statements even if the user didn't specify anything on the command line about apply-convergence-limits. Also, fixed a minor typo.