### PR TITLE
The previous comment was incorrect and was fixed to reflect what is in the code. 

### DIFF
--- a/src/cosmic/src/assign_remnant.f
+++ b/src/cosmic/src/assign_remnant.f
@@ -165,7 +165,8 @@
 *
 * Use the "Delayed" SN Prescription (Fryer et al. 2012, APJ, 749,91)
 *
-*                    For this, we just set the proto-core mass to one
+*                    For this, the proto-core mass varies with CO core mass 
+*                    following section 4.3 equation 18 in Fryer et al. 2012 (APJ, 749, 91)
                if(mc.le.3.5d0)then
                   mcx = 1.2d0
                elseif(mc.le.6.d0)then


### PR DESCRIPTION
The previous comment incorrectly states that the proto-core mass is set to 1. I changed the comment to reflect what is happening in the code, which is based on section 4.3 equation 18 in Fryer et al. 2012. 