### PR TITLE
add alpha1 and acc_lim to the special cases of lists for BSEDict

### DIFF
--- a/docs/generate_default_bsedict.py
+++ b/docs/generate_default_bsedict.py
@@ -28,7 +28,7 @@ def get_default_BSE_settings(to_python=False):
 
     if to_python:
         # ensure array settings are converted from strings to lists
-        for setting in ["qcrit_array", "natal_kick_array", "fprimc_array"]:
+        for setting in ["qcrit_array", "natal_kick_array", "fprimc_array", "alpha1", "acc_lim"]:
             # this one requires special handling because of the fractions
             if setting == "fprimc_array":
                 parts = defaults[setting].strip("[]").split(",")


### PR DESCRIPTION
fixes minor docs error where BSEDict generation was not properly accounting for list inputs for `alpha1` and `acc_lim`. 