### PR TITLE
bhspinmag fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,9 @@
     - Function signature for kick() and evolv2() in the fortran changed to remove ``bkick`` entirely
     - Also removed ``kick_info_out``. Both of these can be reconstructed from ``kick_info``
 
-- Bug fixes: corrected mass sign in bjorklund wind routine in SSE_mlwind.f
+- Bug fixes: c
+    - corrected mass sign in bjorklund wind routine in SSE_mlwind.f
+    - fixed bug in ``bhspinmag`` assignment in ``assign_remnant.f``
 
 ## 4.0.1
 

--- a/src/cosmic/src/assign_remnant.f
+++ b/src/cosmic/src/assign_remnant.f
@@ -712,8 +712,10 @@ collapse BH if the CO core mass is outside the Maltsev+25 range
       IMPLICIT NONE
       INCLUDE 'const_bse.h'
 
-      real*8 ran3, mc, bhspin
+      real  ran3
       EXTERNAL ran3
+
+      real*8 mc, bhspin
 
 * Set all BH spins equal to bhspinmag
       if(bhspinflag.eq.0)then
@@ -731,6 +733,8 @@ collapse BH if the CO core mass is outside the Maltsev+25 range
             bhspin = 0.0d0
          endif
       endif
+
+      WRITE(*,*) 'Assigned BH spin = ', bhspin
 
       end
 

--- a/src/cosmic/src/assign_remnant.f
+++ b/src/cosmic/src/assign_remnant.f
@@ -733,9 +733,7 @@ collapse BH if the CO core mass is outside the Maltsev+25 range
             bhspin = 0.0d0
          endif
       endif
-
-      WRITE(*,*) 'Assigned BH spin = ', bhspin
-
+      
       end
 
       integer function first_mt_type_as_donor(star)


### PR DESCRIPTION
I've made a tiny fix to ran3's definition in `assign_remnant.f` as real rather than real*8 in the bhspin function. This should fix #794 and hopefully not change behavior in the tests 🤞 