### PR TITLE
Added check to skip mass loss-block for dt limits when METISSE is active

### DIFF
--- a/src/cosmic/src/evolv2.f
+++ b/src/cosmic/src/evolv2.f
@@ -1075,7 +1075,7 @@ component.
       do 504 , k = kmin,kmax
 *
          dms(k) = (dmr(k) - dmt(k))*dt
-         if(kstar(k).lt.10)then
+         if(using_METISSE.eq.0.and.kstar(k).lt.10)then
             dml = mass(k) - massc(k)
             if(dml.lt.dms(k))then
                dml = MAX(dml,2.d0*tiny)


### PR DESCRIPTION
Hello,

This request tries to address an issue I see in some COSMIC-METISSE systems. If the mass loss rate is very high (e.g. during LBV or Wolf Rayet-like winds on an 80 Msun MS star), the timestep limit becomes very small (~`1d-16`) and causes evolv2 to run out of iterations very quickly.

This change skips that code block if METISSE is active. I do not think this is necessarily an issue since the winds are "baked in" to the tracks, rather than being added on during the timestep. However, I would very much like to be double-checked on this!

Cheers.

