### PR TITLE
Small fix to inifile/arg parsing in cosmic-pop for METISSE

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -222,10 +222,11 @@ if __name__ == '__main__':
         if hasattr(args, "m2_min") and (args.m2_min is not None):
             if args.m2_min < metisse_m_min:
                 args.m2_min = metisse_m_min
-        elif sampling["m2_min"] is not None:
-            args.m2_min = sampling["m2_min"]
-        if args.m2_min > m1_min:
-            args.m2_min = m1_min
+        elif "m2_min" in sampling:
+            if sampling["m2_min"] is not None:
+                args.m2_min = sampling["m2_min"]
+                if args.m2_min > m1_min:
+                    args.m2_min = m1_min
     else:
         # Check m1_min
         m1_min = args.m1_min


### PR DESCRIPTION
Hello,

Currently, cosmic-pop will throw a `TypeError` under the following specific circumstances:

- the `stellar_engine` is `metisse`
- the inifile value for `m2_min` is commented out (default) or `None` (default value when uncommented)

This exception is related to how m2_min and m1_min are parsed to set the truncation limits for the IMF. For users who use `qmin` instead this can cause a bit of a headache. I changed the indentation levels here to avoid these checks if `m2_min` is not passed or is set to `None`.

The behavior where an exception is thrown if you pass both `qmin` and `m2_min` is preserved.