### PR TITLE
Proposed fix to typo in Eggleton approximation for RLO in independent.sample_porb

### DIFF
--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -971,12 +971,12 @@ class Sample(object):
         # of the period distribution there
         q = mass2 / mass1
         RL_fac = (0.49 * q ** (2.0 / 3.0)) / (
-            0.6 * q ** (2.0 / 3.0) + np.log(1 + q ** 1.0 / 3.0)
+            0.6 * q ** (2.0 / 3.0) + np.log(1 + q ** (1.0 / 3.0))
         )
 
         q2 = mass1 / mass2
         RL_fac2 = (0.49 * q2 ** (2.0 / 3.0)) / (
-            0.6 * q2 ** (2.0 / 3.0) + np.log(1 + q2 ** 1.0 / 3.0)
+            0.6 * q2 ** (2.0 / 3.0) + np.log(1 + q2 ** (1.0 / 3.0))
         )
 
         # include the factor for the eccentricity


### PR DESCRIPTION
This corrects an apparent typo in the Eggleton approximation for Roche Lobe overflow in sample_porb, when computing the minimum porb for the sampler. Specifically, there were no parentheses around the (1/3) exponent in the log term of the denominator. So instead of being log(1+q**(1/3)), as it's supposed to be, the term has been log(1+q**1/3) == log(1+q/3). The resulting R_L can be be smaller by nearly an order of magnitude for q = 0.1; this may imply the sampler has been starting out with too few near-contact binaries for significantly asymmetric mass ratios.

Note: I don't know why the unit test failed. This edit runs fine for me on Quest.