### PR TITLE
low-mass binary fraction in multidim sampler

### DIFF
--- a/src/cosmic/sample/sampler/multidim.py
+++ b/src/cosmic/sample/sampler/multidim.py
@@ -32,6 +32,31 @@ __credits__ = "Scott Coughlin <scott.coughlin@ligo.org>"
 __all__ = ["get_multidim_sampler", "MultiDim"]
 
 
+LOW_MASS_BINARY_FRACTION = 0.20
+LOW_MASS_BINARY_FRACTION_MIN_MASS = 0.08
+LOW_MASS_BINARY_FRACTION_MAX_MASS = 0.8
+
+
+def _rescale_low_mass_binary_cdf(binary_cdf, primary_mass):
+    """Set an absolute 20% binary fraction at 0.08 Msun.
+
+    The target fraction is interpolated in log primary mass to the
+    multidim prediction at 0.8 Msun, where the CDF is left unchanged.
+    """
+    reference_binary_fraction = np.max(binary_cdf)
+    target_binary_fraction = np.interp(
+        np.log10(primary_mass),
+        np.log10(
+            [
+                LOW_MASS_BINARY_FRACTION_MIN_MASS,
+                LOW_MASS_BINARY_FRACTION_MAX_MASS,
+            ]
+        ),
+        [LOW_MASS_BINARY_FRACTION, reference_binary_fraction],
+    )
+    return binary_cdf * target_binary_fraction / reference_binary_fraction
+
+
 def get_multidim_sampler(
     final_kstar1,
     final_kstar2,
@@ -809,7 +834,7 @@ class Worker(object):
             #     ; For M1 = 40 - 150 Msun, adopt binary statistics of M1 = 40 Msun.
             #     ; For M1 = 0.08 - 0.8 Msun, adopt P and e dist of M1 = 0.8Msun,
             #     ; scale and interpolate the companion frequencies so that the
-            #     ; binary star fraction of M1 = 0.08 Msun primaries is zero,
+            #     ; binary star fraction of M1 = 0.08 Msun primaries is 20%,
             #     ; and truncate the q distribution so that q > q_min = 0.08/M1
             indM1 = np.where(abs(myM1 - M1v) == min(abs(myM1 - M1v)))
             indM1 = indM1[0]
@@ -818,7 +843,9 @@ class Worker(object):
             mycumPbindist_flat = (cumPbindist[:, indM1]).flatten()
             # If M1 < 0.8 Msun, rescale to appropriate binary star fraction
             if(myM1 <= 0.8):
-                mycumPbindist_flat = mycumPbindist_flat * np.interp(np.log10(myM1), np.log10([0.08, 0.8]), [0.0, 1.0])
+                mycumPbindist_flat = _rescale_low_mass_binary_cdf(
+                    mycumPbindist_flat, myM1
+                )
 
             # ; Given M1, determine the binary star fraction
             mybinfrac = np.max(mycumPbindist_flat)

--- a/src/cosmic/tests/test_sample.py
+++ b/src/cosmic/tests/test_sample.py
@@ -9,7 +9,10 @@ import numpy as np
 import pandas as pd
 from cosmic.sample import InitialBinaryTable
 from cosmic.sample.sampler.independent import Sample
-from cosmic.sample.sampler.multidim import MultiDim
+from cosmic.sample.sampler.multidim import (
+    MultiDim,
+    _rescale_low_mass_binary_cdf,
+)
 from cosmic.sample.sampler.cmc import CMCSample
 from cosmic.sample.cmc import elson
 from cosmic.sample.initialcmctable import InitialCMCTable
@@ -47,11 +50,11 @@ OFFNER_MASS_RANGES = [(0.075,0.15), (0.15,0.30), (0.3,0.6), (0.75,1.00), (0.85,1
 OFFNER_DATA = [0.19, 0.23, 0.30, 0.42, 0.47, 0.50, 0.68, 0.81, 0.89, 0.93, 0.96]
 OFFNER_ERRORS = [0.03, 0.02, 0.02, 0.03, 0.03, 0.04, 0.07, 0.06, 0.05, 0.04, 0.04]
 MULTIDIM_BINFRAC_MAX = 0.6146916774140262
-MULTIDIM_BINFRAC_MIN = 0.13786300908773025
+MULTIDIM_BINFRAC_MIN = 0.2695344754654569
 CONST_SFR_SUM = 460028.2453521937
 BURST_SFR_SUM = 946002.8245352195
 KSTAR_SOLAR = 1.0
-MOE_TOTAL_MASS = 20.27926225850954
+MOE_TOTAL_MASS = 19.511403220255016
 METALLICITY_1000 = 0.02
 METALLICITY_13000 = 0.02*0.15
 
@@ -497,6 +500,19 @@ class TestSample(unittest.TestCase):
         self.assertEqual(np.sum(mass_singles), MOE_TOTAL_MASS)
         self.assertAlmostEqual(binfrac.max(), MULTIDIM_BINFRAC_MAX)
         self.assertAlmostEqual(binfrac.min(), MULTIDIM_BINFRAC_MIN)
+
+    def test_multidim_low_mass_binary_fraction(self):
+        binary_cdf = np.linspace(0.0, 0.4, 10)
+
+        low_mass_cdf = _rescale_low_mass_binary_cdf(binary_cdf, 0.08)
+        midpoint_cdf = _rescale_low_mass_binary_cdf(
+            binary_cdf, np.sqrt(0.08 * 0.8)
+        )
+        reference_cdf = _rescale_low_mass_binary_cdf(binary_cdf, 0.8)
+
+        self.assertAlmostEqual(low_mass_cdf.max(), 0.20)
+        self.assertAlmostEqual(midpoint_cdf.max(), 0.30)
+        np.testing.assert_allclose(reference_cdf, binary_cdf)
 
     def test_sample_MultiDim_SFH(self):
         np.random.seed(2)


### PR DESCRIPTION
## Summary
I did a small change to multidim.py to:
- set the absolute binary fraction at 0.08 solar masses to 20%, interpolating in log primary mass to the existing multidim prediction at 0.8 solar masses

Made a  regression test and update the seeded sampler expectations

This removes the previous assumption of zero binary fraction at the hydrogen-burning limit. The 20% endpoint is motivated by the observed nonzero multiplicity of very-low-mass stars (e.g. Winters et al. 2019, arXiv:1901.06364).

## Tests

- `pytest -q src/cosmic/tests/test_sample.py`: 28 passed
- `pytest -q src/cosmic/tests`: 113 passed
- `git diff --check`

