### PR TITLE
CMC initialization fix in kick_kiel

### DIFF
--- a/src/cosmic/src/kick.f
+++ b/src/cosmic/src/kick.f
@@ -859,6 +859,9 @@
       if(using_cmc.eq.0)then
           if(kick_info(1,1).eq.0) sn=1
           if(kick_info(1,1).gt.0) sn=2
+      else
+          ! FORCE INITIALIZATION FOR CMC
+          sn = snstar
       endif
 
       if(using_cmc.eq.0)then


### PR DESCRIPTION
Just a two-line change in kick.f that added an initialization for CMC in kick_kiel and fixed a segfault error in CMC-COSMIC.

For debugging and comparison purposes, for the updates from the bkick (vs[20] in CMC) array to the kick_info array in both CMC and COSMIC.